### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,6 +27,11 @@ jobs:
         run: npm test
 
       - name: Publish to npm
-        run: npm publish --provenance --access public
+        run: |
+          if [[ "${{ github.event.release.prerelease }}" == "true" ]]; then
+            npm publish --tag beta --provenance --access public
+          else
+            npm publish --tag latest --provenance --access public
+          fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This workflow would publish the package on NPM whenever a release is created via the GitHub web interface.

It won’t work until an NPM token is added though, which we’ll have to do before publishing the first version.