### PR TITLE
Use extended syntax for bodyParser

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -15,7 +15,11 @@ const expressSettings = require('./express-settings/index')
 
 const NHSPrototypeKit = function (req, res, next) {
   req.app.use(cookieParser())
-  req.app.use(bodyParser.urlencoded())
+  req.app.use(
+    bodyParser.urlencoded({
+      extended: true
+    })
+  )
 
   req.app.use(setCurrentPageInLocals)
 


### PR DESCRIPTION
This is needed to parse `foo[bar]=baz` as:

```
foo: {
  bar: 'baz'
}
```

See https://www.npmjs.com/package/body-parser#bodyparserurlencodedoptions