### PR TITLE
Allow a locals function to be set

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -54,6 +54,10 @@ const NHSPrototypeKit = function (options) {
     }
     req.app.use(autoStoreData)
 
+    if (options.locals) {
+      req.app.use(options.locals)
+    }
+
     if (options.routes) {
       req.app.use(options.routes)
     }
@@ -81,6 +85,7 @@ NHSPrototypeKit.init = function (options) {
   options.express.use(
     NHSPrototypeKit({
       routes: options.routes,
+      locals: options.locals,
       sessionDataDefaults: options.sessionDataDefaults
     })
   )

--- a/testapp/app.js
+++ b/testapp/app.js
@@ -6,6 +6,7 @@ const { join } = require('node:path')
 
 const routes = require('./routes')
 const sessionDataDefaults = require('./data/session-data-defaults')
+const locals = require('./locals')
 
 const app = express()
 const port = 3000
@@ -30,6 +31,7 @@ NHSPrototypeKit.init({
   express: app,
   nunjucks: nunjucksAppEnv,
   routes: routes,
+  locals: locals,
   sessionDataDefaults: sessionDataDefaults
 })
 

--- a/testapp/data/session-data-defaults.js
+++ b/testapp/data/session-data-defaults.js
@@ -1,3 +1,4 @@
 module.exports = {
-  test: 'Default value'
+  test: 'Default value',
+  organisationName: 'NHS'
 }

--- a/testapp/locals.js
+++ b/testapp/locals.js
@@ -1,0 +1,6 @@
+function setLocals(req, res, next) {
+  res.locals.organisationName = req.session.data.organisationName
+  next()
+}
+
+module.exports = setLocals

--- a/testapp/views/index.html
+++ b/testapp/views/index.html
@@ -6,8 +6,10 @@
 
       <p>This index page is being auto-routed.</p>
 
+      <p><code>organisationName</code>: {{ organisationName }}.</p>
+
       <form action="/result" method="post" novalidate="">
-      
+
         {{ input({
           name: "test",
           label: {


### PR DESCRIPTION
This is something the existing kit has, and is useful if you want to set some locals in the views.

You could set this outside of the kit within `app.js`, however then you wouldn’t have access to `req.session.data` within the function.