### PR TITLE
Add NHS frontend 10 as a peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,9 @@
       },
       "engines": {
         "node": "^22"
+      },
+      "peerDependencies": {
+        "nhsuk-frontend": "^10.0.0"
       }
     },
     "node_modules/@noble/hashes": {
@@ -785,6 +788,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/nhsuk-frontend": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/nhsuk-frontend/-/nhsuk-frontend-10.1.0.tgz",
+      "integrity": "sha512-GEetSeLdFyWRUNfWsMyeO+PwqG6upbLa6C8TK5YZg7ljMqTVwKX7WljerZsHwlbRL1izqbnQ2Zl1SO2rsfbSHg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "^20.9.0 || ^22.11.0"
       }
     },
     "node_modules/object-inspect": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
     "cookie-parser": "^1.4.7",
     "express-session": "^1.18.1"
   },
+  "peerDependencies": {
+    "nhsuk-frontend": "^10.0.0"
+  },
   "devDependencies": {
     "express": "^5.1.0",
     "supertest": "7.1.4",

--- a/testapp/package-lock.json
+++ b/testapp/package-lock.json
@@ -35,6 +35,9 @@
       },
       "engines": {
         "node": "^22"
+      },
+      "peerDependencies": {
+        "nhsuk-frontend": "^10.0.0"
       }
     },
     "node_modules/@bufbuild/protobuf": {


### PR DESCRIPTION
The admin views and template depend on version 10 of NHS frontend.