### PR TITLE
Add redirect-post-to-get middleware

### DIFF
--- a/lib/express-middleware/index.js
+++ b/lib/express-middleware/index.js
@@ -9,6 +9,7 @@ const authenticate = require('./authentication')
 const autoRouting = require('./auto-routing')
 const autoStoreData = require('./auto-store-data')
 const productionHeaders = require('./production-headers')
+const redirectPostToGet = require('./redirect-post-to-get')
 const renderErrorPage = require('./render-error-page')
 const renderPageNotFound = require('./render-page-not-found')
 const resetSessionData = require('./reset-session-data')
@@ -113,6 +114,8 @@ function all(options) {
       app.use(options.routes)
     }
 
+    app.use(redirectPostToGet)
+
     // Auto-routes – this must come after custom routes
     app.use(autoRouting.matchRoutes)
 
@@ -129,6 +132,7 @@ module.exports = {
   autoStoreData,
   authenticate,
   productionHeaders,
+  redirectPostToGet,
   renderPageNotFound,
   renderErrorPage,
   resetSessionData,

--- a/lib/express-middleware/redirect-post-to-get.js
+++ b/lib/express-middleware/redirect-post-to-get.js
@@ -1,0 +1,25 @@
+const url = require('node:url')
+
+/**
+ * This Express middleware function redirects all POST
+ * requests to a GET request, to avoid 'Are you sure you
+ * want to send a form again?' when refreshing the page.
+ *
+ * @param {Request} req
+ * @param {Response} res
+ * @param {NextFunction} next
+ */
+function redirectPostToGet(req, res, next) {
+  if (req.method === 'POST') {
+    res.redirect(
+      url.format({
+        pathname: req.path,
+        query: req.query
+      })
+    )
+  } else {
+    next()
+  }
+}
+
+module.exports = redirectPostToGet

--- a/lib/express-middleware/redirect-post-to-get.test.js
+++ b/lib/express-middleware/redirect-post-to-get.test.js
@@ -1,0 +1,51 @@
+const assert = require('node:assert')
+const http = require('node:http')
+const { describe, it } = require('node:test')
+
+const express = require('express')
+const request = require('supertest')
+
+const redirectPostToGet = require('./redirect-post-to-get')
+
+const app = express()
+app.use(redirectPostToGet)
+
+const server = http.createServer(app)
+
+describe('redirectPostToGet', () => {
+  it('adds redirects a POST request to a GET request', async () => {
+    const response = await request(server).post('/form-handler')
+
+    assert.strictEqual(response.status, 302)
+    assert.ok(response.headers.location)
+    assert.strictEqual(response.headers.location, '/form-handler')
+  })
+
+  it('adds does not redirect a GET request', async () => {
+    const response = await request(server).get('/page')
+
+    assert.strictEqual(response.status, 404)
+  })
+
+  it('adds preserves query string when redirecting a POST', async () => {
+    const response = await request(server).post('/form-handler?test=true')
+
+    assert.strictEqual(response.headers.location, '/form-handler?test=true')
+  })
+
+  it('should call next() on get requests', () => {
+    let nextCalled = false
+    let req = {
+      method: 'get'
+    }
+    let res = {}
+
+    const next = () => {
+      nextCalled = true
+    }
+
+    redirectPostToGet(req, res, next)
+
+    assert.strictEqual(nextCalled, true)
+  })
+})


### PR DESCRIPTION

I forgot to add this before, as currently in the kit it’s not included as middleware in `lib/` but instead just as a regex route within `app.js`: https://github.com/nhsuk/nhsuk-prototype-kit/blob/main/app.js#L229-L237

The kit works fine without this, as the auto-routes are still rendering the matching templates on the POST requests. But you do get the 'Are you sure you want to send a form again?' message when refreshing the page, and seeing as the NHS prototype kit (and the GOVUK one) has always had this, I think it’s worth adding.
