### PR TITLE
Rename matchRoutes to autoRoutes

### DIFF
--- a/lib/express-middleware/auto-routes.js
+++ b/lib/express-middleware/auto-routes.js
@@ -42,7 +42,7 @@ function renderPath(path, res, next) {
  * @param {Response} res
  * @param {NextFunction} next
  */
-export function matchRoutes(req, res, next) {
+export function autoRoutes(req, res, next) {
   let { path } = req
 
   path = path.substr(1) // [6] //

--- a/lib/express-middleware/auto-routes.test.js
+++ b/lib/express-middleware/auto-routes.test.js
@@ -7,9 +7,9 @@ import express from 'express'
 import nunjucks from 'nunjucks'
 import request from 'supertest'
 
-import { matchRoutes } from './auto-routing.js'
+import { autoRoutes } from './auto-routes.js'
 
-describe('matchRoutes', () => {
+describe('autoRoutes', () => {
   // Create test templates directory
   const templatesDir = join(import.meta.dirname, 'test-templates')
 
@@ -21,8 +21,8 @@ describe('matchRoutes', () => {
     noCache: true
   })
 
-  // Add the matchRoutes middleware
-  app.use(matchRoutes)
+  // Add the autoRoutes middleware
+  app.use(autoRoutes)
 
   // Add 404 handler
   app.use((req, res) => {

--- a/lib/express-middleware/index.js
+++ b/lib/express-middleware/index.js
@@ -4,7 +4,7 @@ import express from 'express'
 import session from 'express-session'
 
 import { authentication } from './authentication.js'
-import { matchRoutes } from './auto-routing.js'
+import { autoRoutes } from './auto-routes.js'
 import { autoStoreData } from './auto-store-data.js'
 import { productionHeaders } from './production-headers.js'
 import { redirectPostToGet } from './redirect-post-to-get.js'
@@ -16,7 +16,7 @@ import { setSessionDataDefaults } from './set-session-data-defaults.js'
 
 export {
   authentication,
-  matchRoutes,
+  autoRoutes,
   autoStoreData,
   productionHeaders,
   redirectPostToGet,
@@ -128,7 +128,7 @@ export function all(options) {
     app.use(redirectPostToGet)
 
     // Auto-routes – this must come after custom routes
-    app.use(matchRoutes)
+    app.use(autoRoutes)
 
     // Page not found - this must come last
     app.use(renderPageNotFound, renderErrorPage)


### PR DESCRIPTION
This is more consistent with autoStoreData, and brings the file name and the function name together.