### PR TITLE
Move "all" middleware setup out of middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ If you only want to use the Express middleware, you can do this to use everythin
 ```js
 app.use(NHSPrototypeKit.middleware.all({
   serviceName: 'Your service name',
+  express: app,
   routes: routes,
   locals: locals,
   sessionDataDefaults: sessionDataDefaults

--- a/lib/middleware/index.js
+++ b/lib/middleware/index.js
@@ -69,70 +69,70 @@ function configureSession(app, serviceName) {
 // You can pass it some options including:
 //
 // * serviceName - this is added to locals
+// * express - the Express app
 // * locals - a function to set additional locals
 // * routes - additional custom routes
 // * sessionDataDefaults - default data to set in the session
 export function all(options) {
-  return function (req, res, next) {
-    const { app } = req
-    const serviceName = options.serviceName || 'Service name goes here'
+  const app = options.express
+  const serviceName = options.serviceName || 'Service name goes here'
 
-    // Configure core middleware
-    app.use(cookieParser())
-    app.use(bodyParser.urlencoded({ extended: true }))
+  // Configure core middleware
+  app.use(cookieParser())
+  app.use(bodyParser.urlencoded({ extended: true }))
 
-    // Configure session
-    configureSession(app, serviceName)
+  // Configure session
+  configureSession(app, serviceName)
 
-    // Set locals
-    app.use(setCurrentPageInLocals)
-    res.locals.serviceName = serviceName
+  // Set locals
+  app.use(setCurrentPageInLocals)
 
-    // Add production-specific middleware
-    if (process.env.NODE_ENV === 'production') {
-      app.use(productionHeaders)
-      app.use(authentication)
-    }
+  // Add production-specific middleware
+  if (process.env.NODE_ENV === 'production') {
+    app.use(productionHeaders)
+    app.use(authentication)
+  }
 
-    // Use NHS Prototype Kit static assets
+  // Use NHS Prototype Kit static assets
+  app.use(
+    '/nhsuk-prototype-kit-assets',
+    express.static(new URL('assets', import.meta.url).pathname)
+  )
+
+  // Add reset session routes
+  app.use(resetSessionData)
+
+  // Set default session data
+  if (options.sessionDataDefaults) {
     app.use(
-      '/nhsuk-prototype-kit-assets',
-      express.static(new URL('assets', import.meta.url).pathname)
+      setSessionDataDefaults({
+        defaults: options.sessionDataDefaults
+      })
     )
+  }
 
-    // Add reset session routes
-    app.use(resetSessionData)
+  app.use(autoStoreData)
 
-    // Set default session data
-    if (options.sessionDataDefaults) {
-      app.use(
-        setSessionDataDefaults({
-          defaults: options.sessionDataDefaults
-        })
-      )
-    }
+  // Set any other locals
+  if (options.locals) {
+    app.use(options.locals)
+  }
 
-    // Set session data from GET or POST requests
-    app.use(autoStoreData)
+  // Use custom routes
+  if (options.routes) {
+    app.use(options.routes)
+  }
 
-    // Set any other locals
-    if (options.locals) {
-      app.use(options.locals)
-    }
+  app.use(redirectPostToGet)
 
-    // Use custom routes
-    if (options.routes) {
-      app.use(options.routes)
-    }
+  // Auto-routes – this must come after custom routes
+  app.use(autoRoutes)
 
-    app.use(redirectPostToGet)
+  // Page not found - this must come last
+  app.use(renderPageNotFound, renderErrorPage)
 
-    // Auto-routes – this must come after custom routes
-    app.use(autoRoutes)
-
-    // Page not found - this must come last
-    app.use(renderPageNotFound, renderErrorPage)
-
+  return function (req, res, next) {
+    res.locals.serviceName = serviceName
     next()
   }
 }

--- a/lib/nhsuk-prototype-kit.js
+++ b/lib/nhsuk-prototype-kit.js
@@ -55,6 +55,7 @@ NHSPrototypeKit.init = function (options) {
   options.express.use(
     NHSPrototypeKit.middleware.all({
       serviceName: options.serviceName,
+      express: options.express,
       routes: options.routes,
       locals: options.locals,
       sessionDataDefaults: options.sessionDataDefaults


### PR DESCRIPTION
This PR makes sure the setup code for the "all" middleware only runs once

Before returning the middleware function