### PR TITLE
Fix warning: `util._extend` API is deprecated

### DIFF
--- a/lib/nhsuk-prototype-kit.js
+++ b/lib/nhsuk-prototype-kit.js
@@ -3,7 +3,7 @@ import { fileURLToPath } from 'node:url'
 
 import browserSync from 'browser-sync'
 import express from 'express'
-import { createProxyMiddleware } from 'http-proxy-middleware'
+import httpProxy from 'http-proxy-node16'
 
 import { build } from './build/index.js'
 import * as expressSettings from './express-settings/index.js'
@@ -109,17 +109,19 @@ NHSPrototypeKit.prototype.start = async function (port) {
     } else {
       const bs = browserSync.create()
 
+      // We create our own proxy server here
+      // as the default proxy option does not work
+      // on GitHub Codespaces
+      const proxy = httpProxy.createProxyServer({
+        target: `http://localhost:${availablePort}`,
+        changeOrigin: true,
+        xfwd: true
+      })
+
       bs.init({
         port: availablePort,
         files: ['views/**/*.*', 'assets/**/*.*'],
-
-        // We create our own proxy middleware here
-        // as the default proxy option does not work
-        // on GitHub Codespaces.
-        middleware: createProxyMiddleware({
-          changeOrigin: true,
-          target: `http://localhost:${availablePort}`
-        }),
+        middleware: (req, res) => proxy.web(req, res),
         server: {
           baseDir: new URL('public', import.meta.url).pathname
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "esbuild": "^0.27.2",
         "esbuild-sass-plugin": "^3.3.1",
         "express-session": "^1.18.2",
-        "http-proxy-middleware": "^3.0.5",
+        "http-proxy-node16": "^1.0.6",
         "portscanner": "^2.2.0"
       },
       "devDependencies": {
@@ -1539,15 +1539,6 @@
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/http-proxy": {
-      "version": "1.17.17",
-      "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.17.tgz",
-      "integrity": "sha512-ED6LB+Z1AVylNTu7hdzuBqOgMnvG/ld6wGCG8wFnAzKX5uyW2K3WD52v0gnLCTK/VLpXtKckgWuyScYK6cSPaw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
@@ -4993,21 +4984,18 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/http-proxy-middleware": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-3.0.5.tgz",
-      "integrity": "sha512-GLZZm1X38BPY4lkXA01jhwxvDoOkkXqjgVyUzVxiEK4iuRu03PZoYHhHRwxnfhQMDuaxi3vVri0YgSro/1oWqg==",
+    "node_modules/http-proxy-node16": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/http-proxy-node16/-/http-proxy-node16-1.0.6.tgz",
+      "integrity": "sha512-RLtYkbmbLmh+To4lmqLpiEitu0igXb/j1SOW8F6w/esXsapGT5dSShMF9vg7shtxGJSXaWiFE3wYWCoLOuiibg==",
       "license": "MIT",
       "dependencies": {
-        "@types/http-proxy": "^1.17.15",
-        "debug": "^4.3.6",
-        "http-proxy": "^1.18.1",
-        "is-glob": "^4.0.3",
-        "is-plain-object": "^5.0.0",
-        "micromatch": "^4.0.8"
+        "eventemitter3": "^4.0.0",
+        "follow-redirects": "^1.0.0",
+        "requires-port": "^1.0.0"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": ">=8.0.0"
       }
     },
     "node_modules/iconv-lite": {
@@ -5396,15 +5384,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-plain-object": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
-      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/is-promise": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "esbuild": "^0.27.2",
     "esbuild-sass-plugin": "^3.3.1",
     "express-session": "^1.18.2",
-    "http-proxy-middleware": "^3.0.5",
+    "http-proxy-node16": "^1.0.6",
     "portscanner": "^2.2.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
This PR (hopefully) fixes the deprecation warning raised in https://github.com/nhsuk/nhsuk-prototype-kit-package/issues/142

**Update:** Yep, Codespaces works beautifully (once https://github.com/nhsuk/nhsuk-prototype-kit-package/pull/133/changes/6486ce204e0cbd7206acf7c4fa2064bc59c06e72 is fixed)