### PR TITLE
Update README with new API

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ const prototype = NHSPrototypeKit.init({
   locals,
   sessionDataDefaults
 })
+```
 
 ### Using the Nunjucks filters only
 


### PR DESCRIPTION
The `init()` function now no longer needs to be passed a reference to `app` and `nunjucks`.

`NHSPrototypeKit.middleware.all` has been updated to `NHSPrototypeKit.middleware.configure`.