### PR TITLE
Use strict test assertions by default

### DIFF
--- a/lib/express-settings/query-parser.test.js
+++ b/lib/express-settings/query-parser.test.js
@@ -1,4 +1,4 @@
-import assert from 'node:assert'
+import assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
 
 import express from 'express'
@@ -11,6 +11,6 @@ describe('setQueryParser', () => {
   it('adds lets the app use extended query parsing', async () => {
     setQueryParser(app)
 
-    assert.strictEqual(app.get('query parser'), 'extended')
+    assert.equal(app.get('query parser'), 'extended')
   })
 })

--- a/lib/express-settings/trust-proxy.test.js
+++ b/lib/express-settings/trust-proxy.test.js
@@ -1,4 +1,4 @@
-import assert from 'node:assert'
+import assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
 
 import express from 'express'
@@ -11,6 +11,6 @@ describe('setTrustProxy', () => {
   it('adds sets the app to trust proxies', async () => {
     setTrustProxy(app)
 
-    assert.strictEqual(app.get('trust proxy'), 1)
+    assert.equal(app.get('trust proxy'), 1)
   })
 })

--- a/lib/express-settings/view-engine.test.js
+++ b/lib/express-settings/view-engine.test.js
@@ -1,4 +1,4 @@
-import assert from 'node:assert'
+import assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
 
 import express from 'express'
@@ -11,6 +11,6 @@ describe('setViewEngine', () => {
   it('adds sets the app to use HTML for its views', async () => {
     setViewEngine(app)
 
-    assert.strictEqual(app.get('view engine'), 'html')
+    assert.equal(app.get('view engine'), 'html')
   })
 })

--- a/lib/index.test.cjs
+++ b/lib/index.test.cjs
@@ -1,4 +1,4 @@
-const assert = require('node:assert')
+const assert = require('node:assert/strict')
 const { describe, it } = require('node:test')
 
 const express = require('express')
@@ -9,11 +9,11 @@ const NHSPrototypeKit = require('./index.cjs')
 describe('CommonJS default exports', () => {
   it('should export NHSPrototypeKit as default', () => {
     assert.ok(NHSPrototypeKit)
-    assert.strictEqual(typeof NHSPrototypeKit, 'function')
+    assert.equal(typeof NHSPrototypeKit, 'function')
   })
 
   it('should have init method', () => {
-    assert.strictEqual(typeof NHSPrototypeKit.init, 'function')
+    assert.equal(typeof NHSPrototypeKit.init, 'function')
   })
 
   it('should be able to create instances', () => {
@@ -34,23 +34,23 @@ describe('CommonJS package exports', () => {
 
   it('should export middleware', () => {
     assert.ok(middleware)
-    assert.strictEqual(typeof middleware, 'object')
-    assert.strictEqual(typeof middleware.configure, 'function')
-    assert.strictEqual(typeof middleware.autoRoutes, 'function')
+    assert.equal(typeof middleware, 'object')
+    assert.equal(typeof middleware.configure, 'function')
+    assert.equal(typeof middleware.autoRoutes, 'function')
   })
 
   it('should export nunjucksFilters', () => {
     assert.ok(nunjucksFilters)
-    assert.strictEqual(typeof nunjucksFilters, 'object')
-    assert.strictEqual(typeof nunjucksFilters.addAll, 'function')
-    assert.strictEqual(typeof nunjucksFilters.formatNhsNumber, 'function')
-    assert.strictEqual(typeof nunjucksFilters.log, 'function')
-    assert.strictEqual(typeof nunjucksFilters.startsWith, 'function')
+    assert.equal(typeof nunjucksFilters, 'object')
+    assert.equal(typeof nunjucksFilters.addAll, 'function')
+    assert.equal(typeof nunjucksFilters.formatNhsNumber, 'function')
+    assert.equal(typeof nunjucksFilters.log, 'function')
+    assert.equal(typeof nunjucksFilters.startsWith, 'function')
   })
 
   it('should export utils', () => {
     assert.ok(utils)
-    assert.strictEqual(typeof utils, 'object')
-    assert.strictEqual(typeof utils.findAvailablePort, 'function')
+    assert.equal(typeof utils, 'object')
+    assert.equal(typeof utils.findAvailablePort, 'function')
   })
 })

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -1,4 +1,4 @@
-import assert from 'node:assert'
+import assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
 
 import NHSPrototypeKit, {
@@ -10,28 +10,28 @@ import NHSPrototypeKit, {
 describe('ES module named exports', () => {
   it('should export NHSPrototypeKit as default', () => {
     assert.ok(NHSPrototypeKit)
-    assert.strictEqual(typeof NHSPrototypeKit, 'function')
+    assert.equal(typeof NHSPrototypeKit, 'function')
   })
 
   it('should export middleware as a named export', () => {
     assert.ok(middleware)
-    assert.strictEqual(typeof middleware, 'object')
-    assert.strictEqual(typeof middleware.configure, 'function')
-    assert.strictEqual(typeof middleware.autoRoutes, 'function')
+    assert.equal(typeof middleware, 'object')
+    assert.equal(typeof middleware.configure, 'function')
+    assert.equal(typeof middleware.autoRoutes, 'function')
   })
 
   it('should export nunjucksFilters as a named export', () => {
     assert.ok(nunjucksFilters)
-    assert.strictEqual(typeof nunjucksFilters, 'object')
-    assert.strictEqual(typeof nunjucksFilters.addAll, 'function')
-    assert.strictEqual(typeof nunjucksFilters.formatNhsNumber, 'function')
-    assert.strictEqual(typeof nunjucksFilters.log, 'function')
-    assert.strictEqual(typeof nunjucksFilters.startsWith, 'function')
+    assert.equal(typeof nunjucksFilters, 'object')
+    assert.equal(typeof nunjucksFilters.addAll, 'function')
+    assert.equal(typeof nunjucksFilters.formatNhsNumber, 'function')
+    assert.equal(typeof nunjucksFilters.log, 'function')
+    assert.equal(typeof nunjucksFilters.startsWith, 'function')
   })
 
   it('should export utils as a named export', () => {
     assert.ok(utils)
-    assert.strictEqual(typeof utils, 'object')
-    assert.strictEqual(typeof utils.findAvailablePort, 'function')
+    assert.equal(typeof utils, 'object')
+    assert.equal(typeof utils.findAvailablePort, 'function')
   })
 })

--- a/lib/middleware/authentication.test.js
+++ b/lib/middleware/authentication.test.js
@@ -1,4 +1,4 @@
-import assert from 'node:assert'
+import assert from 'node:assert/strict'
 import { createHash } from 'node:crypto'
 import { dirname, join } from 'node:path'
 import { describe, it, beforeEach, afterEach } from 'node:test'
@@ -62,7 +62,7 @@ describe('authentication', () => {
       delete process.env.PROTOTYPE_PASSWORD
       const response = await request(app).get('/')
 
-      assert.strictEqual(response.statusCode, 401)
+      assert.equal(response.statusCode, 401)
       assert.ok(response.text.includes('Password not set'))
       assert.ok(
         response.text.includes(
@@ -81,7 +81,7 @@ describe('authentication', () => {
       it('should allow access to /prototype-admin/password', async () => {
         const response = await request(app).get('/prototype-admin/password')
 
-        assert.strictEqual(response.statusCode, 200)
+        assert.equal(response.statusCode, 200)
         assert(response.text.includes('Enter password'))
       })
 
@@ -90,7 +90,7 @@ describe('authentication', () => {
           '/prototype-admin/password?error=wrong-password&returnURL=%2Ftest'
         )
 
-        assert.strictEqual(response.statusCode, 200)
+        assert.equal(response.statusCode, 200)
         assert(response.text.includes('The password is not correct'))
       })
 
@@ -99,7 +99,7 @@ describe('authentication', () => {
           '/nhsuk-frontend/nhsuk-frontend.min.css'
         )
 
-        assert.strictEqual(response.statusCode, 200)
+        assert.equal(response.statusCode, 200)
       })
 
       it('should allow access to /nhsuk-frontend/nhsuk-frontend.min.css.map', async () => {
@@ -107,7 +107,7 @@ describe('authentication', () => {
           '/nhsuk-frontend/nhsuk-frontend.min.css.map'
         )
 
-        assert.strictEqual(response.statusCode, 200)
+        assert.equal(response.statusCode, 200)
       })
 
       it('should allow access to /nhsuk-frontend/nhsuk-frontend.min.js', async () => {
@@ -115,7 +115,7 @@ describe('authentication', () => {
           '/nhsuk-frontend/nhsuk-frontend.min.js'
         )
 
-        assert.strictEqual(response.statusCode, 200)
+        assert.equal(response.statusCode, 200)
       })
 
       it('should allow access to NHS Frontend assets', async () => {
@@ -123,7 +123,7 @@ describe('authentication', () => {
           '/nhsuk-frontend/assets/logos/logo.svg'
         )
 
-        assert.strictEqual(response.statusCode, 200)
+        assert.equal(response.statusCode, 200)
       })
 
       it('should allow access to other NHS Frontend assets', async () => {
@@ -131,7 +131,7 @@ describe('authentication', () => {
           '/nhsuk-frontend/assets/images/favicon.svg'
         )
 
-        assert.strictEqual(response.statusCode, 200)
+        assert.equal(response.statusCode, 200)
       })
     })
 
@@ -146,8 +146,8 @@ describe('authentication', () => {
           .get('/some-protected-page')
           .set('Cookie', `authentication=${authCookie}`)
 
-        assert.strictEqual(response.statusCode, 200)
-        assert.strictEqual(response.text, 'OK')
+        assert.equal(response.statusCode, 200)
+        assert.equal(response.text, 'OK')
       })
 
       it('should allow access to root path', async () => {
@@ -160,8 +160,8 @@ describe('authentication', () => {
           .get('/')
           .set('Cookie', `authentication=${authCookie}`)
 
-        assert.strictEqual(response.statusCode, 200)
-        assert.strictEqual(response.text, 'OK')
+        assert.equal(response.statusCode, 200)
+        assert.equal(response.text, 'OK')
       })
     })
 
@@ -169,7 +169,7 @@ describe('authentication', () => {
       it('should redirect to password page', async () => {
         const response = await request(app).get('/some-protected-page')
 
-        assert.strictEqual(response.statusCode, 302)
+        assert.equal(response.statusCode, 302)
         assert.ok(response.headers.location)
         assert.ok(
           response.headers.location.startsWith('/prototype-admin/password')
@@ -179,7 +179,7 @@ describe('authentication', () => {
       it('should include returnURL in redirect', async () => {
         const response = await request(app).get('/some-protected-page')
 
-        assert.strictEqual(response.statusCode, 302)
+        assert.equal(response.statusCode, 302)
         assert.ok(
           response.headers.location.includes('returnURL=%2Fsome-protected-page')
         )
@@ -188,7 +188,7 @@ describe('authentication', () => {
       it('should preserve query parameters in returnURL', async () => {
         const response = await request(app).get('/some-page?foo=bar&baz=qux')
 
-        assert.strictEqual(response.statusCode, 302)
+        assert.equal(response.statusCode, 302)
         // Query params are encoded in the returnURL parameter
         assert.ok(response.headers.location.includes('returnURL='))
         // The returnURL should contain the encoded query string
@@ -200,7 +200,7 @@ describe('authentication', () => {
       it('should redirect root path to password page', async () => {
         const response = await request(app).get('/')
 
-        assert.strictEqual(response.statusCode, 302)
+        assert.equal(response.statusCode, 302)
         assert.ok(
           response.headers.location.startsWith('/prototype-admin/password')
         )
@@ -213,7 +213,7 @@ describe('authentication', () => {
           .get('/some-protected-page')
           .set('Cookie', 'authentication=invalidhash')
 
-        assert.strictEqual(response.statusCode, 302)
+        assert.equal(response.statusCode, 302)
         assert.ok(
           response.headers.location.startsWith('/prototype-admin/password')
         )
@@ -227,8 +227,8 @@ describe('authentication', () => {
           .type('form')
           .send({ password: 'testpassword', returnURL: '/dashboard' })
 
-        assert.strictEqual(response.statusCode, 302)
-        assert.strictEqual(response.headers.location, '/dashboard')
+        assert.equal(response.statusCode, 302)
+        assert.equal(response.headers.location, '/dashboard')
         assert.ok(response.headers['set-cookie'])
         assert.ok(response.headers['set-cookie'][0].includes('authentication='))
       })
@@ -239,7 +239,7 @@ describe('authentication', () => {
           .type('form')
           .send({ password: 'wrongpassword', returnURL: '/dashboard' })
 
-        assert.strictEqual(response.statusCode, 302)
+        assert.equal(response.statusCode, 302)
         assert.ok(response.headers.location.includes('error=wrong-password'))
         assert.ok(response.headers.location.includes('returnURL=%2Fdashboard'))
       })
@@ -250,8 +250,8 @@ describe('authentication', () => {
           .type('form')
           .send({ password: 'testpassword' })
 
-        assert.strictEqual(response.statusCode, 302)
-        assert.strictEqual(response.headers.location, '/')
+        assert.equal(response.statusCode, 302)
+        assert.equal(response.headers.location, '/')
       })
     })
   })

--- a/lib/middleware/auto-routes.test.js
+++ b/lib/middleware/auto-routes.test.js
@@ -1,4 +1,4 @@
-import assert from 'node:assert'
+import assert from 'node:assert/strict'
 import http from 'node:http'
 import { join } from 'node:path'
 import { describe, it } from 'node:test'
@@ -39,103 +39,79 @@ describe('autoRoutes', () => {
   describe('root path', () => {
     it('should render index.html for root path', async () => {
       const response = await request(server).get('/')
-      assert.strictEqual(response.status, 200)
-      assert.strictEqual(response.text, 'Test index page\n')
-      assert.strictEqual(
-        response.headers['content-type'],
-        'text/html; charset=utf-8'
-      )
+      assert.equal(response.status, 200)
+      assert.equal(response.text, 'Test index page\n')
+      assert.equal(response.headers['content-type'], 'text/html; charset=utf-8')
     })
   })
 
   describe('simple path', () => {
     it('should render simple.html for /simple path', async () => {
       const response = await request(server).get('/simple')
-      assert.strictEqual(response.status, 200)
-      assert.strictEqual(response.text, 'Simple test page\n')
-      assert.strictEqual(
-        response.headers['content-type'],
-        'text/html; charset=utf-8'
-      )
+      assert.equal(response.status, 200)
+      assert.equal(response.text, 'Simple test page\n')
+      assert.equal(response.headers['content-type'], 'text/html; charset=utf-8')
     })
 
     it('should render simple.html for /simple.html path', async () => {
       const response = await request(server).get('/simple.html')
-      assert.strictEqual(response.status, 200)
-      assert.strictEqual(response.text, 'Simple test page\n')
-      assert.strictEqual(
-        response.headers['content-type'],
-        'text/html; charset=utf-8'
-      )
+      assert.equal(response.status, 200)
+      assert.equal(response.text, 'Simple test page\n')
+      assert.equal(response.headers['content-type'], 'text/html; charset=utf-8')
     })
   })
 
   describe('path matching a .njk view', () => {
     it('should render with-njk.njk for /with-njk path', async () => {
       const response = await request(server).get('/with-njk')
-      assert.strictEqual(response.status, 200)
-      assert.strictEqual(response.text, 'Test page using njk extension\n')
-      assert.strictEqual(
-        response.headers['content-type'],
-        'text/html; charset=utf-8'
-      )
+      assert.equal(response.status, 200)
+      assert.equal(response.text, 'Test page using njk extension\n')
+      assert.equal(response.headers['content-type'], 'text/html; charset=utf-8')
     })
   })
 
   describe('nested path with index', () => {
     it('should render nested/index.html for /nested path', async () => {
       const response = await request(server).get('/nested')
-      assert.strictEqual(response.status, 200)
-      assert.strictEqual(response.text, 'Nested index page\n')
-      assert.strictEqual(
-        response.headers['content-type'],
-        'text/html; charset=utf-8'
-      )
+      assert.equal(response.status, 200)
+      assert.equal(response.text, 'Nested index page\n')
+      assert.equal(response.headers['content-type'], 'text/html; charset=utf-8')
     })
 
     it('should render nested/index.html for /nested/ path with trailing slash', async () => {
       const response = await request(server).get('/nested/')
-      assert.strictEqual(response.status, 200)
-      assert.strictEqual(response.text, 'Nested index page\n')
-      assert.strictEqual(
-        response.headers['content-type'],
-        'text/html; charset=utf-8'
-      )
+      assert.equal(response.status, 200)
+      assert.equal(response.text, 'Nested index page\n')
+      assert.equal(response.headers['content-type'], 'text/html; charset=utf-8')
     })
 
     it('should render a nestee index.njk for /nested path', async () => {
       const response = await request(server).get('/nested-with-njk')
-      assert.strictEqual(response.status, 200)
-      assert.strictEqual(
-        response.text,
-        'Nested index page using njk extension\n'
-      )
-      assert.strictEqual(
-        response.headers['content-type'],
-        'text/html; charset=utf-8'
-      )
+      assert.equal(response.status, 200)
+      assert.equal(response.text, 'Nested index page using njk extension\n')
+      assert.equal(response.headers['content-type'], 'text/html; charset=utf-8')
     })
   })
 
   describe('non-existent paths', () => {
     it('should call next() for non-existent template', async () => {
       const response = await request(server).get('/does-not-exist')
-      assert.strictEqual(response.status, 404)
-      assert.strictEqual(response.text, 'Not found')
+      assert.equal(response.status, 404)
+      assert.equal(response.text, 'Not found')
     })
 
     it('should call next() for non-existent nested path', async () => {
       const response = await request(server).get('/path/does/not/exist')
-      assert.strictEqual(response.status, 404)
-      assert.strictEqual(response.text, 'Not found')
+      assert.equal(response.status, 404)
+      assert.equal(response.text, 'Not found')
     })
   })
 
   describe('template errors', () => {
     it('should call next(error) for template rendering errors', async () => {
       const response = await request(server).get('/error')
-      assert.strictEqual(response.status, 500)
-      assert.strictEqual(response.text, 'Template error')
+      assert.equal(response.status, 500)
+      assert.equal(response.text, 'Template error')
     })
   })
 })

--- a/lib/middleware/auto-store-data.test.js
+++ b/lib/middleware/auto-store-data.test.js
@@ -1,4 +1,4 @@
-import assert from 'node:assert'
+import assert from 'node:assert/strict'
 import { describe, it, beforeEach, mock } from 'node:test'
 
 import { autoStoreData } from './auto-store-data.js'
@@ -27,7 +27,7 @@ describe('autoStoreData middleware', () => {
       autoStoreData(req, res, next)
 
       assert.ok(req.session.data, 'session.data should be initialized')
-      assert.deepStrictEqual(req.session.data, {})
+      assert.deepEqual(req.session.data, {})
     })
 
     it('should preserve existing session.data', () => {
@@ -35,13 +35,13 @@ describe('autoStoreData middleware', () => {
 
       autoStoreData(req, res, next)
 
-      assert.strictEqual(req.session.data.existingKey, 'existingValue')
+      assert.equal(req.session.data.existingKey, 'existingValue')
     })
 
     it('should call next()', () => {
       autoStoreData(req, res, next)
 
-      assert.strictEqual(next.mock.callCount(), 1)
+      assert.equal(next.mock.callCount(), 1)
     })
   })
 
@@ -55,9 +55,9 @@ describe('autoStoreData middleware', () => {
 
       autoStoreData(req, res, next)
 
-      assert.strictEqual(req.session.data.firstName, 'John')
-      assert.strictEqual(req.session.data.lastName, 'Doe')
-      assert.strictEqual(req.session.data.age, '30')
+      assert.equal(req.session.data.firstName, 'John')
+      assert.equal(req.session.data.lastName, 'Doe')
+      assert.equal(req.session.data.age, '30')
     })
 
     it('should store array values from body', () => {
@@ -67,7 +67,7 @@ describe('autoStoreData middleware', () => {
 
       autoStoreData(req, res, next)
 
-      assert.deepStrictEqual(req.session.data.colors, ['red', 'blue', 'green'])
+      assert.deepEqual(req.session.data.colors, ['red', 'blue', 'green'])
     })
 
     it('should store nested objects from body', () => {
@@ -81,7 +81,7 @@ describe('autoStoreData middleware', () => {
 
       autoStoreData(req, res, next)
 
-      assert.deepStrictEqual(req.session.data.address, {
+      assert.deepEqual(req.session.data.address, {
         street: '123 Main St',
         city: 'London',
         postcode: 'SW1A 1AA'
@@ -98,8 +98,8 @@ describe('autoStoreData middleware', () => {
 
       autoStoreData(req, res, next)
 
-      assert.strictEqual(req.session.data.search, 'test query')
-      assert.strictEqual(req.session.data.page, '2')
+      assert.equal(req.session.data.search, 'test query')
+      assert.equal(req.session.data.page, '2')
     })
 
     it('should store array values from query', () => {
@@ -109,7 +109,7 @@ describe('autoStoreData middleware', () => {
 
       autoStoreData(req, res, next)
 
-      assert.deepStrictEqual(req.session.data.tags, ['javascript', 'nodejs'])
+      assert.deepEqual(req.session.data.tags, ['javascript', 'nodejs'])
     })
   })
 
@@ -124,8 +124,8 @@ describe('autoStoreData middleware', () => {
 
       autoStoreData(req, res, next)
 
-      assert.strictEqual(req.session.data.name, 'John')
-      assert.strictEqual(req.session.data.id, '123')
+      assert.equal(req.session.data.name, 'John')
+      assert.equal(req.session.data.id, '123')
     })
 
     it('should give query priority over body when both have same key', () => {
@@ -138,7 +138,7 @@ describe('autoStoreData middleware', () => {
 
       autoStoreData(req, res, next)
 
-      assert.strictEqual(req.session.data.value, 'from-query')
+      assert.equal(req.session.data.value, 'from-query')
     })
   })
 
@@ -152,9 +152,9 @@ describe('autoStoreData middleware', () => {
 
       autoStoreData(req, res, next)
 
-      assert.strictEqual(req.session.data.name, 'John')
-      assert.strictEqual(req.session.data._csrf, undefined)
-      assert.strictEqual(req.session.data._internal, undefined)
+      assert.equal(req.session.data.name, 'John')
+      assert.equal(req.session.data._csrf, undefined)
+      assert.equal(req.session.data._internal, undefined)
     })
 
     it('should ignore fields starting with underscore in query', () => {
@@ -165,8 +165,8 @@ describe('autoStoreData middleware', () => {
 
       autoStoreData(req, res, next)
 
-      assert.strictEqual(req.session.data.search, 'test')
-      assert.strictEqual(req.session.data._debug, undefined)
+      assert.equal(req.session.data.search, 'test')
+      assert.equal(req.session.data._debug, undefined)
     })
   })
 
@@ -182,8 +182,8 @@ describe('autoStoreData middleware', () => {
 
       autoStoreData(req, res, next)
 
-      assert.strictEqual(req.session.data.newsletter, undefined)
-      assert.strictEqual(req.session.data.updates, 'yes')
+      assert.equal(req.session.data.newsletter, undefined)
+      assert.equal(req.session.data.updates, 'yes')
     })
 
     it('should filter _unchecked from array values', () => {
@@ -193,7 +193,7 @@ describe('autoStoreData middleware', () => {
 
       autoStoreData(req, res, next)
 
-      assert.deepStrictEqual(req.session.data.preferences, ['email', 'sms'])
+      assert.deepEqual(req.session.data.preferences, ['email', 'sms'])
     })
 
     it('should handle array with all _unchecked values', () => {
@@ -203,7 +203,7 @@ describe('autoStoreData middleware', () => {
 
       autoStoreData(req, res, next)
 
-      assert.deepStrictEqual(req.session.data.options, [])
+      assert.deepEqual(req.session.data.options, [])
     })
 
     it('should handle array with no _unchecked values', () => {
@@ -213,7 +213,7 @@ describe('autoStoreData middleware', () => {
 
       autoStoreData(req, res, next)
 
-      assert.deepStrictEqual(req.session.data.colors, ['red', 'blue'])
+      assert.deepEqual(req.session.data.colors, ['red', 'blue'])
     })
   })
 
@@ -234,7 +234,7 @@ describe('autoStoreData middleware', () => {
 
       autoStoreData(req, res, next)
 
-      assert.deepStrictEqual(req.session.data.user, {
+      assert.deepEqual(req.session.data.user, {
         name: 'John',
         email: 'newemail@example.com',
         phone: '123456789'
@@ -251,7 +251,7 @@ describe('autoStoreData middleware', () => {
 
       autoStoreData(req, res, next)
 
-      assert.deepStrictEqual(req.session.data.profile, {
+      assert.deepEqual(req.session.data.profile, {
         firstName: 'Jane',
         lastName: 'Smith'
       })
@@ -269,7 +269,7 @@ describe('autoStoreData middleware', () => {
 
       autoStoreData(req, res, next)
 
-      assert.deepStrictEqual(req.session.data.address, {
+      assert.deepEqual(req.session.data.address, {
         home: {
           street: '123 Main St',
           city: 'London'
@@ -289,7 +289,7 @@ describe('autoStoreData middleware', () => {
 
       autoStoreData(req, res, next)
 
-      assert.deepStrictEqual(req.session.data.user, {
+      assert.deepEqual(req.session.data.user, {
         name: 'John'
       })
     })
@@ -304,7 +304,7 @@ describe('autoStoreData middleware', () => {
 
       autoStoreData(req, res, next)
 
-      assert.deepStrictEqual(req.session.data.user, {
+      assert.deepEqual(req.session.data.user, {
         name: 'John'
       })
     })
@@ -319,8 +319,8 @@ describe('autoStoreData middleware', () => {
 
       autoStoreData(req, res, next)
 
-      assert.strictEqual(res.locals.data.name, 'John')
-      assert.strictEqual(res.locals.data.age, '30')
+      assert.equal(res.locals.data.name, 'John')
+      assert.equal(res.locals.data.age, '30')
     })
 
     it('should copy existing session.data to res.locals.data', () => {
@@ -331,15 +331,15 @@ describe('autoStoreData middleware', () => {
 
       autoStoreData(req, res, next)
 
-      assert.strictEqual(res.locals.data.existingKey, 'existingValue')
-      assert.strictEqual(res.locals.data.anotherKey, 'anotherValue')
+      assert.equal(res.locals.data.existingKey, 'existingValue')
+      assert.equal(res.locals.data.anotherKey, 'anotherValue')
     })
 
     it('should initialize res.locals.data as empty object when session.data is empty', () => {
       autoStoreData(req, res, next)
 
       assert.ok(res.locals.data)
-      assert.deepStrictEqual(res.locals.data, {})
+      assert.deepEqual(res.locals.data, {})
     })
 
     it('should reflect updates from body in res.locals.data', () => {
@@ -353,8 +353,8 @@ describe('autoStoreData middleware', () => {
 
       autoStoreData(req, res, next)
 
-      assert.strictEqual(res.locals.data.name, 'Jane')
-      assert.strictEqual(res.locals.data.email, 'jane@example.com')
+      assert.equal(res.locals.data.name, 'Jane')
+      assert.equal(res.locals.data.email, 'jane@example.com')
     })
   })
 
@@ -385,7 +385,7 @@ describe('autoStoreData middleware', () => {
       autoStoreData(req, res, next)
 
       // Nested object should be merged
-      assert.deepStrictEqual(req.session.data.user, {
+      assert.deepEqual(req.session.data.user, {
         name: 'John',
         email: 'john@example.com',
         preferences: {
@@ -394,24 +394,24 @@ describe('autoStoreData middleware', () => {
       })
 
       // _unchecked should delete the field
-      assert.strictEqual(req.session.data.newsletter, undefined)
+      assert.equal(req.session.data.newsletter, undefined)
 
       // _unchecked should be filtered from array
-      assert.deepStrictEqual(req.session.data.colors, ['red', 'blue'])
+      assert.deepEqual(req.session.data.colors, ['red', 'blue'])
 
       // Fields starting with _ should be ignored
-      assert.strictEqual(req.session.data._csrf, undefined)
-      assert.strictEqual(req.session.data._debug, undefined)
+      assert.equal(req.session.data._csrf, undefined)
+      assert.equal(req.session.data._debug, undefined)
 
       // Query data should be stored
-      assert.strictEqual(req.session.data.page, '1')
+      assert.equal(req.session.data.page, '1')
 
       // All data should be in res.locals.data
-      assert.strictEqual(res.locals.data.page, '1')
-      assert.deepStrictEqual(res.locals.data.colors, ['red', 'blue'])
+      assert.equal(res.locals.data.page, '1')
+      assert.deepEqual(res.locals.data.colors, ['red', 'blue'])
 
       // next should be called
-      assert.strictEqual(next.mock.callCount(), 1)
+      assert.equal(next.mock.callCount(), 1)
     })
   })
 })

--- a/lib/middleware/production-headers.test.js
+++ b/lib/middleware/production-headers.test.js
@@ -1,4 +1,4 @@
-import assert from 'node:assert'
+import assert from 'node:assert/strict'
 import http from 'node:http'
 import { describe, it } from 'node:test'
 
@@ -16,7 +16,7 @@ describe('productionHeaders', () => {
   it('adds content security policy', async () => {
     const response = await request(server).get('/nonexistent')
 
-    assert.strictEqual(
+    assert.equal(
       response.headers['content-security-policy'],
       'upgrade-insecure-requests'
     )
@@ -25,7 +25,7 @@ describe('productionHeaders', () => {
   it('adds Strict-Transport-Security', async () => {
     const response = await request(server).get('/nonexistent')
 
-    assert.strictEqual(
+    assert.equal(
       response.headers['strict-transport-security'],
       'max-age=31536000; includeSubDomains; preload'
     )
@@ -36,11 +36,8 @@ describe('productionHeaders', () => {
       .get('/secure-only')
       .set('Host', 'example.com')
 
-    assert.strictEqual(response.status, 302)
-    assert.strictEqual(
-      response.headers.location,
-      'https://example.com/secure-only'
-    )
+    assert.equal(response.status, 302)
+    assert.equal(response.headers.location, 'https://example.com/secure-only')
   })
 
   it('calls next() when protocol is already https', async () => {
@@ -56,9 +53,9 @@ describe('productionHeaders', () => {
       .get('/test')
       .set('X-Forwarded-Proto', 'https')
 
-    assert.strictEqual(response.status, 200)
-    assert.strictEqual(response.text, 'OK')
-    assert.strictEqual(
+    assert.equal(response.status, 200)
+    assert.equal(response.text, 'OK')
+    assert.equal(
       response.headers['content-security-policy'],
       'upgrade-insecure-requests'
     )

--- a/lib/middleware/redirect-post-to-get.test.js
+++ b/lib/middleware/redirect-post-to-get.test.js
@@ -1,4 +1,4 @@
-import assert from 'node:assert'
+import assert from 'node:assert/strict'
 import http from 'node:http'
 import { describe, it, beforeEach, mock } from 'node:test'
 
@@ -27,21 +27,21 @@ describe('redirectPostToGet', () => {
   it('adds redirects a POST request to a GET request', async () => {
     const response = await request(server).post('/form-handler')
 
-    assert.strictEqual(response.status, 302)
+    assert.equal(response.status, 302)
     assert.ok(response.headers.location)
-    assert.strictEqual(response.headers.location, '/form-handler')
+    assert.equal(response.headers.location, '/form-handler')
   })
 
   it('adds does not redirect a GET request', async () => {
     const response = await request(server).get('/page')
 
-    assert.strictEqual(response.status, 404)
+    assert.equal(response.status, 404)
   })
 
   it('adds preserves query string when redirecting a POST', async () => {
     const response = await request(server).post('/form-handler?test=true')
 
-    assert.strictEqual(response.headers.location, '/form-handler?test=true')
+    assert.equal(response.headers.location, '/form-handler?test=true')
   })
 
   it('should call next() on get requests', () => {
@@ -49,7 +49,7 @@ describe('redirectPostToGet', () => {
 
     redirectPostToGet(req, res, next)
 
-    assert.strictEqual(next.mock.callCount(), 1)
+    assert.equal(next.mock.callCount(), 1)
   })
 })
 

--- a/lib/middleware/render-error-page.test.js
+++ b/lib/middleware/render-error-page.test.js
@@ -1,4 +1,4 @@
-import assert from 'node:assert'
+import assert from 'node:assert/strict'
 import http from 'node:http'
 import { join } from 'node:path'
 import { describe, it, beforeEach, afterEach } from 'node:test'
@@ -42,17 +42,17 @@ describe('renderErrorPage', () => {
 
   it('sets the 500 status code', async () => {
     const response = await request(server).get('/error')
-    assert.strictEqual(response.status, 500)
+    assert.equal(response.status, 500)
   })
 
   it('renders the 500.html template', async () => {
     const response = await request(server).get('/error')
-    assert.strictEqual(response.text, 'Server error\n')
+    assert.equal(response.text, 'Server error\n')
   })
 
   it('calls console.error() with the error', async () => {
     await request(server).get('/error')
-    assert.strictEqual(errorCalls.length, 1)
+    assert.equal(errorCalls.length, 1)
     assert.ok(errorCalls[0][0].startsWith('Error: Template error'))
   })
 
@@ -73,6 +73,6 @@ describe('renderErrorPage', () => {
     customApp.use(renderErrorPage)
 
     const response = await request(customApp).get('/test')
-    assert.strictEqual(response.status, 503)
+    assert.equal(response.status, 503)
   })
 })

--- a/lib/middleware/render-page-not-found.test.js
+++ b/lib/middleware/render-page-not-found.test.js
@@ -1,4 +1,4 @@
-import assert from 'node:assert'
+import assert from 'node:assert/strict'
 import http from 'node:http'
 import { join } from 'node:path'
 import { describe, it, beforeEach } from 'node:test'
@@ -37,12 +37,12 @@ describe('renderPageNotFound', () => {
 
   it('sets the 404 status code', async () => {
     const response = await request(server).get('/nonexistent')
-    assert.strictEqual(response.status, 404)
+    assert.equal(response.status, 404)
   })
 
   it('renders the 404.html template', async () => {
     const response = await request(server).get('/nonexistent')
-    assert.strictEqual(response.text, 'Page not found\n')
+    assert.equal(response.text, 'Page not found\n')
   })
 
   it('passes the request path to the template', (context) => {
@@ -50,7 +50,7 @@ describe('renderPageNotFound', () => {
 
     renderPageNotFound(req, res)
 
-    assert.deepStrictEqual(render.mock.calls[0].arguments, [
+    assert.deepEqual(render.mock.calls[0].arguments, [
       '404',
       { path: '/test-path' }
     ])

--- a/lib/middleware/reset-session-data.test.js
+++ b/lib/middleware/reset-session-data.test.js
@@ -1,4 +1,4 @@
-import assert from 'node:assert'
+import assert from 'node:assert/strict'
 import { describe, it, beforeEach, mock } from 'node:test'
 
 import { resetSessionData } from './reset-session-data.js'
@@ -40,7 +40,7 @@ describe('resetSessionData middleware', () => {
       req.query.returnPage = '/custom-page'
       resetSessionData(req, res, next)
 
-      assert.deepStrictEqual(render.mock.calls[0].arguments, [
+      assert.deepEqual(render.mock.calls[0].arguments, [
         'reset',
         { returnPage: '/custom-page' }
       ])
@@ -49,7 +49,7 @@ describe('resetSessionData middleware', () => {
     it('should use "/" as default returnPage when not provided', () => {
       resetSessionData(req, res, next)
 
-      assert.deepStrictEqual(render.mock.calls[0].arguments, [
+      assert.deepEqual(render.mock.calls[0].arguments, [
         'reset',
         { returnPage: '/' }
       ])
@@ -57,7 +57,7 @@ describe('resetSessionData middleware', () => {
 
     it('should not call next()', () => {
       resetSessionData(req, res, next)
-      assert.strictEqual(next.mock.callCount(), 0)
+      assert.equal(next.mock.callCount(), 0)
     })
   })
 
@@ -73,9 +73,9 @@ describe('resetSessionData middleware', () => {
       req.body.returnPage = '/dashboard'
       resetSessionData(req, res, next)
 
-      assert.deepStrictEqual(req.session.data, {})
+      assert.deepEqual(req.session.data, {})
 
-      assert.deepStrictEqual(render.mock.calls[0].arguments, [
+      assert.deepEqual(render.mock.calls[0].arguments, [
         'reset-done',
         { returnPage: '/dashboard' }
       ])
@@ -84,9 +84,9 @@ describe('resetSessionData middleware', () => {
     it('should use "/" as default when returnPage not provided', () => {
       resetSessionData(req, res, next)
 
-      assert.deepStrictEqual(req.session.data, {})
+      assert.deepEqual(req.session.data, {})
 
-      assert.deepStrictEqual(render.mock.calls[0].arguments, [
+      assert.deepEqual(render.mock.calls[0].arguments, [
         'reset-done',
         { returnPage: '/' }
       ])
@@ -96,7 +96,7 @@ describe('resetSessionData middleware', () => {
       req.body.returnPage = 'https://malicious.com'
       resetSessionData(req, res, next)
 
-      assert.deepStrictEqual(render.mock.calls[0].arguments, [
+      assert.deepEqual(render.mock.calls[0].arguments, [
         'reset-done',
         { returnPage: '/' }
       ])
@@ -106,7 +106,7 @@ describe('resetSessionData middleware', () => {
       req.body.returnPage = 'relative-path'
       resetSessionData(req, res, next)
 
-      assert.deepStrictEqual(render.mock.calls[0].arguments, [
+      assert.deepEqual(render.mock.calls[0].arguments, [
         'reset-done',
         { returnPage: '/' }
       ])
@@ -116,7 +116,7 @@ describe('resetSessionData middleware', () => {
       req.body.returnPage = '/page?foo=bar'
       resetSessionData(req, res, next)
 
-      assert.deepStrictEqual(render.mock.calls[0].arguments, [
+      assert.deepEqual(render.mock.calls[0].arguments, [
         'reset-done',
         { returnPage: '/page?foo=bar' }
       ])
@@ -126,12 +126,12 @@ describe('resetSessionData middleware', () => {
       req.session.data = { key1: 'value1', key2: 'value2' }
       resetSessionData(req, res, next)
 
-      assert.deepStrictEqual(req.session.data, {})
+      assert.deepEqual(req.session.data, {})
     })
 
     it('should not call next()', () => {
       resetSessionData(req, res, next)
-      assert.strictEqual(next.mock.callCount(), 0)
+      assert.equal(next.mock.callCount(), 0)
     })
   })
 
@@ -143,7 +143,7 @@ describe('resetSessionData middleware', () => {
 
       resetSessionData(req, res, next)
 
-      assert.strictEqual(next.mock.callCount(), 1)
+      assert.equal(next.mock.callCount(), 1)
     })
 
     it('should set res.locals.currentPage for all requests', () => {
@@ -154,7 +154,7 @@ describe('resetSessionData middleware', () => {
 
       resetSessionData(req, res, next)
 
-      assert.strictEqual(res.locals.currentPage, '/test-url?param=value')
+      assert.equal(res.locals.currentPage, '/test-url?param=value')
     })
   })
 
@@ -173,14 +173,14 @@ describe('resetSessionData middleware', () => {
 
       resetSessionData(req, res, next)
 
-      assert.deepStrictEqual(req.session.data, {})
+      assert.deepEqual(req.session.data, {})
 
-      assert.deepStrictEqual(render.mock.calls[0].arguments, [
+      assert.deepEqual(render.mock.calls[0].arguments, [
         'reset-done',
         { returnPage: '/' }
       ])
 
-      assert.strictEqual(next.mock.callCount(), 0)
+      assert.equal(next.mock.callCount(), 0)
     })
   })
 })

--- a/lib/middleware/set-current-page-in-locals.test.js
+++ b/lib/middleware/set-current-page-in-locals.test.js
@@ -1,4 +1,4 @@
-import assert from 'node:assert'
+import assert from 'node:assert/strict'
 import { describe, it, beforeEach, mock } from 'node:test'
 
 import { setCurrentPageInLocals } from './set-current-page-in-locals.js'
@@ -25,16 +25,13 @@ describe('setCurrentPageInLocals middleware', () => {
 
     setCurrentPageInLocals(req, res, next)
 
-    assert.deepStrictEqual(
-      res.locals.currentPage,
-      '/this/is/a/test?query=string'
-    )
+    assert.deepEqual(res.locals.currentPage, '/this/is/a/test?query=string')
   })
 
   it('should call next()', () => {
     setCurrentPageInLocals(req, res, next)
 
-    assert.strictEqual(next.mock.callCount(), 1)
+    assert.equal(next.mock.callCount(), 1)
   })
 })
 

--- a/lib/middleware/set-session-data-defaults.test.js
+++ b/lib/middleware/set-session-data-defaults.test.js
@@ -1,4 +1,4 @@
-import assert from 'node:assert'
+import assert from 'node:assert/strict'
 import { describe, it, beforeEach, mock } from 'node:test'
 
 import { setSessionDataDefaults } from './set-session-data-defaults.js'
@@ -26,8 +26,8 @@ describe('setSessionDataDefaults middleware', () => {
     middleware(req, res, next)
 
     assert.ok(req.session.data, 'session.data should be initialized')
-    assert.deepStrictEqual(req.session.data, {})
-    assert.strictEqual(next.mock.callCount(), 1)
+    assert.deepEqual(req.session.data, {})
+    assert.equal(next.mock.callCount(), 1)
   })
 
   it('should set default values when session.data is empty', () => {
@@ -39,8 +39,8 @@ describe('setSessionDataDefaults middleware', () => {
 
     middleware(req, res, next)
 
-    assert.deepStrictEqual(req.session.data, defaults)
-    assert.strictEqual(next.mock.callCount(), 1)
+    assert.deepEqual(req.session.data, defaults)
+    assert.equal(next.mock.callCount(), 1)
   })
 
   it('should preserve existing session data over defaults', () => {
@@ -58,18 +58,18 @@ describe('setSessionDataDefaults middleware', () => {
     middleware(req, res, next)
 
     // Existing values should be preserved, defaults should be added
-    assert.strictEqual(
+    assert.equal(
       req.session.data.name,
       'Jane Smith',
       'existing name should be preserved'
     )
-    assert.strictEqual(
+    assert.equal(
       req.session.data.email,
       'jane@example.com',
       'existing email should be preserved'
     )
-    assert.strictEqual(req.session.data.age, 30, 'default age should be added')
-    assert.strictEqual(next.mock.callCount(), 1)
+    assert.equal(req.session.data.age, 30, 'default age should be added')
+    assert.equal(next.mock.callCount(), 1)
   })
 
   it('should throw TypeError when options.defaults is not provided', () => {

--- a/lib/nhsuk-prototype-kit.test.js
+++ b/lib/nhsuk-prototype-kit.test.js
@@ -1,4 +1,4 @@
-import assert from 'node:assert'
+import assert from 'node:assert/strict'
 import { dirname, join } from 'node:path'
 import { describe, it, before, mock } from 'node:test'
 import { fileURLToPath } from 'node:url'
@@ -22,9 +22,9 @@ describe('NHSPrototypeKit', () => {
         buildOptions: buildOptions
       })
 
-      assert.strictEqual(prototype.app, app)
-      assert.strictEqual(prototype.nunjucks, nunjucksEnv)
-      assert.strictEqual(prototype.buildOptions, buildOptions)
+      assert.equal(prototype.app, app)
+      assert.equal(prototype.nunjucks, nunjucksEnv)
+      assert.equal(prototype.buildOptions, buildOptions)
     })
 
     it('should work with minimal options', () => {
@@ -33,9 +33,9 @@ describe('NHSPrototypeKit', () => {
         nunjucks: nunjucksEnv
       })
 
-      assert.strictEqual(prototype.app, app)
-      assert.strictEqual(prototype.nunjucks, nunjucksEnv)
-      assert.strictEqual(prototype.buildOptions, undefined)
+      assert.equal(prototype.app, app)
+      assert.equal(prototype.nunjucks, nunjucksEnv)
+      assert.equal(prototype.buildOptions, undefined)
     })
   })
 
@@ -62,9 +62,9 @@ describe('NHSPrototypeKit', () => {
         app: customApp
       })
 
-      assert.strictEqual(customApp.get('view engine'), 'html')
-      assert.deepStrictEqual(customApp.get('nunjucksEnv'), prototype.nunjucks)
-      assert.deepStrictEqual(prototype.app, customApp)
+      assert.equal(customApp.get('view engine'), 'html')
+      assert.deepEqual(customApp.get('nunjucksEnv'), prototype.nunjucks)
+      assert.deepEqual(prototype.app, customApp)
     })
 
     it('should initialize with custom nunjucks environment', async () => {
@@ -74,8 +74,8 @@ describe('NHSPrototypeKit', () => {
         nunjucks: customNunjucksEnv
       })
 
-      assert.strictEqual(prototype.app.get('view engine'), 'html')
-      assert.deepStrictEqual(customNunjucksEnv, prototype.nunjucks)
+      assert.equal(prototype.app.get('view engine'), 'html')
+      assert.deepEqual(customNunjucksEnv, prototype.nunjucks)
     })
 
     it('should initialize with custom express app and nunjucks environment', async () => {
@@ -90,19 +90,19 @@ describe('NHSPrototypeKit', () => {
         nunjucks: customNunjucksEnv
       })
 
-      assert.strictEqual(customApp.get('view engine'), 'html')
-      assert.deepStrictEqual(customApp.get('nunjucksEnv'), prototype.nunjucks)
-      assert.deepStrictEqual(customApp.get('nunjucksEnv'), customNunjucksEnv)
-      assert.deepStrictEqual(prototype.app, customApp)
+      assert.equal(customApp.get('view engine'), 'html')
+      assert.deepEqual(customApp.get('nunjucksEnv'), prototype.nunjucks)
+      assert.deepEqual(customApp.get('nunjucksEnv'), customNunjucksEnv)
+      assert.deepEqual(prototype.app, customApp)
     })
 
     it('should set express settings', async () => {
       const prototype = await NHSPrototypeKit.init()
 
       // Check that express settings were applied
-      assert.strictEqual(prototype.app.get('query parser'), 'extended')
-      assert.strictEqual(prototype.app.get('trust proxy'), 1)
-      assert.strictEqual(prototype.app.get('view engine'), 'html')
+      assert.equal(prototype.app.get('query parser'), 'extended')
+      assert.equal(prototype.app.get('trust proxy'), 1)
+      assert.equal(prototype.app.get('view engine'), 'html')
     })
 
     it('should configure nunjucks with correct paths', async () => {
@@ -126,7 +126,7 @@ describe('NHSPrototypeKit', () => {
         join(frontendPath, 'dist')
       ]
 
-      assert.deepStrictEqual(
+      assert.deepEqual(
         // @ts-expect-error - Property 'loaders' does not exist
         prototype.nunjucks.loaders[0].searchPaths,
         expectedSearchPaths
@@ -137,7 +137,7 @@ describe('NHSPrototypeKit', () => {
       const prototype = await NHSPrototypeKit.init()
 
       // @ts-expect-error - Property 'opts' does not exist
-      assert.strictEqual(prototype.nunjucks.opts.noCache, true)
+      assert.equal(prototype.nunjucks.opts.noCache, true)
     })
 
     it('should initialize with custom viewsPath', async () => {
@@ -175,7 +175,7 @@ describe('NHSPrototypeKit', () => {
       assert.ok(prototype instanceof NHSPrototypeKit)
       assert.ok(prototype.app)
       assert.ok(prototype.nunjucks)
-      assert.strictEqual(prototype.buildOptions, buildOptions)
+      assert.equal(prototype.buildOptions, buildOptions)
     })
   })
 
@@ -228,7 +228,7 @@ describe('NHSPrototypeKit', () => {
 
       await prototype.start()
 
-      assert.strictEqual(listen.mock.calls[0].arguments[0], 3000)
+      assert.equal(listen.mock.calls[0].arguments[0], 3000)
     })
 
     it('should ignore server port argument in production mode', async () => {
@@ -239,7 +239,7 @@ describe('NHSPrototypeKit', () => {
 
       await prototype.start(4000)
 
-      assert.strictEqual(listen.mock.calls[0].arguments[0], 3000)
+      assert.equal(listen.mock.calls[0].arguments[0], 3000)
     })
 
     it('should handle configured server port', async () => {
@@ -252,7 +252,7 @@ describe('NHSPrototypeKit', () => {
 
       await prototype.start()
 
-      assert.strictEqual(listen.mock.calls[0].arguments[0], 4000)
+      assert.equal(listen.mock.calls[0].arguments[0], 4000)
     })
 
     it('should handle PORT environment variable', async () => {
@@ -265,7 +265,7 @@ describe('NHSPrototypeKit', () => {
 
       await prototype.start()
 
-      assert.strictEqual(listen.mock.calls[0].arguments[0], 3500)
+      assert.equal(listen.mock.calls[0].arguments[0], 3500)
     })
 
     it('should handle PORT environment variable (overriding express)', async () => {
@@ -284,7 +284,7 @@ describe('NHSPrototypeKit', () => {
 
       await prototype.start()
 
-      assert.strictEqual(listen.mock.calls[0].arguments[0], 3500)
+      assert.equal(listen.mock.calls[0].arguments[0], 3500)
     })
 
     it('should handle PORT environment variable (overriding express and start)', async () => {
@@ -303,7 +303,7 @@ describe('NHSPrototypeKit', () => {
 
       await prototype.start(3000)
 
-      assert.strictEqual(listen.mock.calls[0].arguments[0], 3500)
+      assert.equal(listen.mock.calls[0].arguments[0], 3500)
     })
   })
 })

--- a/lib/nunjucks-filters/format-nhs-number.test.js
+++ b/lib/nunjucks-filters/format-nhs-number.test.js
@@ -1,34 +1,34 @@
-import assert from 'node:assert'
+import assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
 
 import { formatNhsNumber } from './format-nhs-number.js'
 
 describe('formatNhsNumber', () => {
   it('should format a string of 10 digits', () => {
-    assert.strictEqual(formatNhsNumber('9991231230'), '999 123 1230')
+    assert.equal(formatNhsNumber('9991231230'), '999 123 1230')
   })
 
   it('should format 10 digits as a number', () => {
-    assert.strictEqual(formatNhsNumber(9991231230), '999 123 1230')
+    assert.equal(formatNhsNumber(9991231230), '999 123 1230')
   })
 
   it('should format a string of 10 digits containing spaces', () => {
-    assert.strictEqual(formatNhsNumber('9 991 23 123 0  '), '999 123 1230')
+    assert.equal(formatNhsNumber('9 991 23 123 0  '), '999 123 1230')
   })
 
   it('should format a string of 10 digits and other characters', () => {
-    assert.strictEqual(formatNhsNumber('999-123-123-0'), '999 123 1230')
+    assert.equal(formatNhsNumber('999-123-123-0'), '999 123 1230')
   })
 
   it('should not format a string of less than 10 digits', () => {
-    assert.strictEqual(formatNhsNumber('99912345'), '99912345')
+    assert.equal(formatNhsNumber('99912345'), '99912345')
   })
 
   it('should not format a string of more than 10 digits', () => {
-    assert.strictEqual(formatNhsNumber('9991234567123'), '9991234567123')
+    assert.equal(formatNhsNumber('9991234567123'), '9991234567123')
   })
 
   it('should return null for null', () => {
-    assert.strictEqual(formatNhsNumber(null), null)
+    assert.equal(formatNhsNumber(null), null)
   })
 })

--- a/lib/nunjucks-filters/starts-with.test.js
+++ b/lib/nunjucks-filters/starts-with.test.js
@@ -1,14 +1,14 @@
-import assert from 'node:assert'
+import assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
 
 import { startsWith } from './starts-with.js'
 
 describe('startsWith', () => {
   it('matches string', () => {
-    assert.strictEqual(startsWith('NHS England', 'NHS'), true)
+    assert.equal(startsWith('NHS England', 'NHS'), true)
   })
 
   it('does not match string', () => {
-    assert.strictEqual(startsWith('DHSC', 'NHS'), false)
+    assert.equal(startsWith('DHSC', 'NHS'), false)
   })
 })


### PR DESCRIPTION
Instead of choosing between strict and non-strict assertions can we use `'node:assert/strict'`?

This PR switches all the tests over