### PR TITLE
Add new Nunjucks filters

### DIFF
--- a/lib/index.test.cjs
+++ b/lib/index.test.cjs
@@ -82,6 +82,7 @@ describe('CommonJS package exports', () => {
     assert.equal(typeof nunjucksFilters.addAll, 'function')
     assert.equal(typeof nunjucksFilters.formatNhsNumber, 'function')
     assert.equal(typeof nunjucksFilters.formatPostcode, 'function')
+    assert.equal(typeof nunjucksFilters.isNumeric, 'function')
     assert.equal(typeof nunjucksFilters.log, 'function')
     assert.equal(typeof nunjucksFilters.startsWith, 'function')
   })

--- a/lib/index.test.cjs
+++ b/lib/index.test.cjs
@@ -80,6 +80,7 @@ describe('CommonJS package exports', () => {
     assert.ok(nunjucksFilters)
     assert.equal(typeof nunjucksFilters, 'object')
     assert.equal(typeof nunjucksFilters.addAll, 'function')
+    assert.equal(typeof nunjucksFilters.formatCurrency, 'function')
     assert.equal(typeof nunjucksFilters.formatNhsNumber, 'function')
     assert.equal(typeof nunjucksFilters.formatNumber, 'function')
     assert.equal(typeof nunjucksFilters.formatPostcode, 'function')

--- a/lib/index.test.cjs
+++ b/lib/index.test.cjs
@@ -81,6 +81,7 @@ describe('CommonJS package exports', () => {
     assert.equal(typeof nunjucksFilters, 'object')
     assert.equal(typeof nunjucksFilters.addAll, 'function')
     assert.equal(typeof nunjucksFilters.formatNhsNumber, 'function')
+    assert.equal(typeof nunjucksFilters.formatNumber, 'function')
     assert.equal(typeof nunjucksFilters.formatPostcode, 'function')
     assert.equal(typeof nunjucksFilters.isNumeric, 'function')
     assert.equal(typeof nunjucksFilters.log, 'function')

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -36,6 +36,7 @@ describe('ES module named exports', () => {
     assert.ok(nunjucksFilters)
     assert.equal(typeof nunjucksFilters, 'object')
     assert.equal(typeof nunjucksFilters.addAll, 'function')
+    assert.equal(typeof nunjucksFilters.formatCurrency, 'function')
     assert.equal(typeof nunjucksFilters.formatNhsNumber, 'function')
     assert.equal(typeof nunjucksFilters.formatNumber, 'function')
     assert.equal(typeof nunjucksFilters.formatPostcode, 'function')

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -38,6 +38,7 @@ describe('ES module named exports', () => {
     assert.equal(typeof nunjucksFilters.addAll, 'function')
     assert.equal(typeof nunjucksFilters.formatNhsNumber, 'function')
     assert.equal(typeof nunjucksFilters.formatPostcode, 'function')
+    assert.equal(typeof nunjucksFilters.isNumeric, 'function')
     assert.equal(typeof nunjucksFilters.log, 'function')
     assert.equal(typeof nunjucksFilters.startsWith, 'function')
   })

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -37,6 +37,7 @@ describe('ES module named exports', () => {
     assert.equal(typeof nunjucksFilters, 'object')
     assert.equal(typeof nunjucksFilters.addAll, 'function')
     assert.equal(typeof nunjucksFilters.formatNhsNumber, 'function')
+    assert.equal(typeof nunjucksFilters.formatNumber, 'function')
     assert.equal(typeof nunjucksFilters.formatPostcode, 'function')
     assert.equal(typeof nunjucksFilters.isNumeric, 'function')
     assert.equal(typeof nunjucksFilters.log, 'function')

--- a/lib/nunjucks-filters/format-currency.js
+++ b/lib/nunjucks-filters/format-currency.js
@@ -1,0 +1,32 @@
+import { formatNumber } from './format-number.js'
+import { isNumeric } from './is-numeric.js'
+
+/**
+ * Format currency
+ *
+ * @param {string | number} [value] - Value to format
+ */
+export function formatCurrency(value = '') {
+  let minimumFractionDigits = 2
+  let maximumFractionDigits = 2
+
+  const number = formatNumber(value)
+
+  if (!isNumeric(number)) {
+    return value
+  }
+
+  // Decimal places are optional for '.00'
+  if (number === Number.parseInt(`${number}`, 10)) {
+    minimumFractionDigits = 0
+    maximumFractionDigits = 0
+  }
+
+  // Format as currency string
+  return number.toLocaleString('en-GB', {
+    style: 'currency',
+    currency: 'GBP',
+    minimumFractionDigits,
+    maximumFractionDigits
+  })
+}

--- a/lib/nunjucks-filters/format-currency.test.js
+++ b/lib/nunjucks-filters/format-currency.test.js
@@ -1,0 +1,124 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+
+import { formatCurrency } from './format-currency.js'
+
+describe('formatCurrency', () => {
+  it('should format numbers', () => {
+    assert.equal(formatCurrency(300), '£300')
+    assert.equal(formatCurrency(300.5), '£300.50')
+    assert.equal(formatCurrency(300.59), '£300.59')
+    assert.equal(formatCurrency(300.591), '£300.59')
+    assert.equal(formatCurrency(300.599), '£300.60')
+  })
+
+  it('should format negative numbers', () => {
+    assert.equal(formatCurrency(-300), '-£300')
+    assert.equal(formatCurrency(-300.5), '-£300.50')
+    assert.equal(formatCurrency(-300.59), '-£300.59')
+    assert.equal(formatCurrency(-300.591), '-£300.59')
+    assert.equal(formatCurrency(-300.599), '-£300.60')
+  })
+
+  it('should format numeric strings', () => {
+    // Hundreds
+    assert.equal(formatCurrency('300'), '£300')
+    assert.equal(formatCurrency('300.0'), '£300')
+    assert.equal(formatCurrency('300.00'), '£300')
+    assert.equal(formatCurrency('300.5'), '£300.50')
+    assert.equal(formatCurrency('300.50'), '£300.50')
+    assert.equal(formatCurrency('300.59'), '£300.59')
+    assert.equal(formatCurrency('300.591'), '£300.59')
+    assert.equal(formatCurrency('300.599'), '£300.60')
+
+    // Thousands
+    assert.equal(formatCurrency('3000'), '£3,000')
+    assert.equal(formatCurrency('3000.0'), '£3,000')
+    assert.equal(formatCurrency('3000.00'), '£3,000')
+    assert.equal(formatCurrency('3000.5'), '£3,000.50')
+    assert.equal(formatCurrency('3000.50'), '£3,000.50')
+    assert.equal(formatCurrency('3000.59'), '£3,000.59')
+    assert.equal(formatCurrency('3000.591'), '£3,000.59')
+    assert.equal(formatCurrency('3000.599'), '£3,000.60')
+
+    // 10s of thousands
+    assert.equal(formatCurrency('30000'), '£30,000')
+    assert.equal(formatCurrency('30000.0'), '£30,000')
+    assert.equal(formatCurrency('30000.00'), '£30,000')
+    assert.equal(formatCurrency('30000.5'), '£30,000.50')
+    assert.equal(formatCurrency('30000.50'), '£30,000.50')
+    assert.equal(formatCurrency('30000.59'), '£30,000.59')
+    assert.equal(formatCurrency('30000.591'), '£30,000.59')
+    assert.equal(formatCurrency('30000.599'), '£30,000.60')
+
+    // 100s of thousands
+    assert.equal(formatCurrency('300000'), '£300,000')
+    assert.equal(formatCurrency('300000.0'), '£300,000')
+    assert.equal(formatCurrency('300000.00'), '£300,000')
+    assert.equal(formatCurrency('300000.5'), '£300,000.50')
+    assert.equal(formatCurrency('300000.50'), '£300,000.50')
+    assert.equal(formatCurrency('300000.59'), '£300,000.59')
+    assert.equal(formatCurrency('300000.591'), '£300,000.59')
+    assert.equal(formatCurrency('300000.599'), '£300,000.60')
+
+    // Millions
+    assert.equal(formatCurrency('3000000'), '£3,000,000')
+    assert.equal(formatCurrency('3000000.0'), '£3,000,000')
+    assert.equal(formatCurrency('3000000.00'), '£3,000,000')
+    assert.equal(formatCurrency('3000000.5'), '£3,000,000.50')
+    assert.equal(formatCurrency('3000000.50'), '£3,000,000.50')
+    assert.equal(formatCurrency('3000000.59'), '£3,000,000.59')
+    assert.equal(formatCurrency('3000000.591'), '£3,000,000.59')
+    assert.equal(formatCurrency('3000000.599'), '£3,000,000.60')
+  })
+
+  it('should format numeric strings (badly formatted)', () => {
+    assert.equal(formatCurrency('3,00,0,0'), '£30,000')
+    assert.equal(formatCurrency('3,00,0,0.50'), '£30,000.50')
+    assert.equal(formatCurrency('3,00,0,0.51'), '£30,000.51')
+    assert.equal(formatCurrency('3,00,0,0.512'), '£30,000.51')
+    assert.equal(formatCurrency('3,00,0,0.519'), '£30,000.52')
+    assert.equal(formatCurrency('3,0,0,0,0.50'), '£30,000.50')
+    assert.equal(formatCurrency('3,0,0,0,0.51'), '£30,000.51')
+    assert.equal(formatCurrency('3,0,0,0,0.512'), '£30,000.51')
+    assert.equal(formatCurrency('3,0,0,0,0.519'), '£30,000.52')
+  })
+
+  it('should format numeric strings (accidental spaces)', () => {
+    assert.equal(formatCurrency('3 ,00,0,0 '), '£30,000')
+    assert.equal(formatCurrency('3,00,0,0 .50'), '£30,000.50')
+    assert.equal(formatCurrency('3, 00,0,0 .51'), '£30,000.51')
+    assert.equal(formatCurrency('3,00,0,0  .512'), '£30,000.51')
+    assert.equal(formatCurrency('3,0 0,0,0 .519'), '£30,000.52')
+    assert.equal(formatCurrency('3,0,0, 0,0.50'), '£30,000.50')
+    assert.equal(formatCurrency('3, 0,0,0,0 .51'), '£30,000.51')
+    assert.equal(formatCurrency('3,0,0,0,0  .512'), '£30,000.51')
+    assert.equal(formatCurrency('3,0, 0,0,0 .519'), '£30,000.52')
+  })
+
+  it('should format numeric strings (with symbols)', () => {
+    assert.equal(formatCurrency('£3,00,0,0'), '£30,000')
+    assert.equal(formatCurrency('£3,00,0,0.50'), '£30,000.50')
+    assert.equal(formatCurrency('£3,00,0,0.51'), '£30,000.51')
+    assert.equal(formatCurrency('£3,00,0,0.512'), '£30,000.51')
+    assert.equal(formatCurrency('£3,00,0,0.519'), '£30,000.52')
+    assert.equal(formatCurrency('£3,0,0,0,0.50'), '£30,000.50')
+    assert.equal(formatCurrency('£3,0,0,0,0.51'), '£30,000.51')
+    assert.equal(formatCurrency('£3,0,0,0,0.512'), '£30,000.51')
+    assert.equal(formatCurrency('£3,0,0,0,0.519'), '£30,000.52')
+  })
+
+  it('should format numeric strings (total mess)', () => {
+    assert.equal(formatCurrency('£3,00,,,0,0 ...512'), '£30,000.51')
+    assert.equal(formatCurrency('£3,0 0,0,0 .519$%'), '£30,000.52')
+    assert.equal(formatCurrency('£3,0,0, 0,0.50AA'), '£30,000.50')
+    assert.equal(formatCurrency('%3, 0,0,0,0 .51C'), '£30,000.51')
+    assert.equal(formatCurrency('$3,0, 0,0,0 .519'), '£30,000.52')
+  })
+
+  it('should not format non-numeric strings', () => {
+    assert.equal(formatCurrency('ABCDEFGH'), 'ABCDEFGH')
+    assert.equal(formatCurrency('!@£$%^&*()'), '!@£$%^&*()')
+    assert.equal(formatCurrency('!A@B£C$D%E'), '!A@B£C$D%E')
+  })
+})

--- a/lib/nunjucks-filters/format-nhs-number.js
+++ b/lib/nunjucks-filters/format-nhs-number.js
@@ -1,5 +1,7 @@
+import { formatNumber } from './format-number.js'
+
 /**
- * Display an NHS number formatted with spaces
+ * Format an NHS number with spaces
  *
  * The format is 3 3 4: 2 groups of 3 digits followed by 4 digits.
  *
@@ -11,17 +13,20 @@
  *
  * See https://service-manual.nhs.uk/content/a-to-z-of-nhs-health-writing#nhs-number
  *
- * @param {string | number} [nhsNumber] - the NHS number to format
- * @returns {string | number | undefined} Formatted NHS number
+ * @param {string | number} [value] - Value to format as NHS number
  */
-export function formatNhsNumber(nhsNumber) {
-  const digitsOnly = String(nhsNumber).replace(/[^0-9]/g, '')
+export function formatNhsNumber(value) {
+  const digitsOnly = formatNumber(value, '[^0-9]')?.toString()
 
-  if (digitsOnly.length !== 10) {
-    return nhsNumber
+  if (digitsOnly?.length !== 10) {
+    return value
   }
 
-  const formatted = `${digitsOnly.substring(0, 3)} ${digitsOnly.substring(3, 6)} ${digitsOnly.substring(6, 10)}`
+  // Split "9991234567" into groups
+  const group1 = digitsOnly.substring(0, 3)
+  const group2 = digitsOnly.substring(3, 6)
+  const group3 = digitsOnly.substring(6, 10)
 
-  return formatted
+  // Add spaces to become "999 123 4567"
+  return `${group1} ${group2} ${group3}`
 }

--- a/lib/nunjucks-filters/format-number.js
+++ b/lib/nunjucks-filters/format-number.js
@@ -1,0 +1,25 @@
+import { isNumeric } from './is-numeric.js'
+
+/**
+ * Format number
+ *
+ * @param {string | number} [value] - Value to format
+ * @param {string} [disallow] - Regex string to disallow
+ */
+export function formatNumber(value = '', disallow = '[^0-9.-]+') {
+  const normalised = `${value}`
+    .replaceAll(/\s+/g, '')
+
+    // Only allow '-' at start
+    .replaceAll(/(?!^)-/g, '')
+
+    // Only allow certain characters
+    .replaceAll(new RegExp(disallow, 'g'), '')
+
+    // Only allow the last decimal point
+    .replaceAll(/[.](?=.*[.])/g, '')
+
+  // Attempt to parse as float
+  const number = Number.parseFloat(`${normalised}`)
+  return isNumeric(number) ? number : undefined
+}

--- a/lib/nunjucks-filters/format-number.test.js
+++ b/lib/nunjucks-filters/format-number.test.js
@@ -1,0 +1,49 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+
+import { formatNumber } from './format-number.js'
+
+describe('formatNumber', () => {
+  it('should format numeric strings with non-numeric characters', () => {
+    assert.equal(formatNumber(' 999 123 4567 '), 9991234567)
+    assert.equal(formatNumber(' 999-123-4567 '), 9991234567)
+    assert.equal(formatNumber('999-123-4567'), 9991234567)
+    assert.equal(formatNumber('999 123 4567'), 9991234567)
+    assert.equal(formatNumber('999 1234567'), 9991234567)
+    assert.equal(formatNumber('9991234567'), 9991234567)
+
+    assert.equal(formatNumber('150kg'), 150)
+    assert.equal(formatNumber('£10.50'), 10.5)
+    assert.equal(formatNumber('10,000'), 10000)
+    assert.equal(formatNumber('10,000,000'), 10000000)
+
+    assert.equal(formatNumber('-150Nm'), -150)
+    assert.equal(formatNumber('-£10.50'), -10.5)
+    assert.equal(formatNumber('-10,000'), -10000)
+    assert.equal(formatNumber('-10,000,000'), -10000000)
+  })
+
+  it('should format numeric strings with custom characters by regex string', () => {
+    assert.equal(formatNumber('-999-123-4567-', '[^0-9]'), 9991234567)
+    assert.equal(formatNumber('999-123-4567', '[^0-9]'), 9991234567)
+    assert.equal(formatNumber('.999.123.4567.', '[^0-9]'), 9991234567)
+    assert.equal(formatNumber('999.123.4567', '[^0-9]'), 9991234567)
+  })
+
+  it('should format numeric strings with unexpected decimal points', () => {
+    assert.equal(formatNumber('10,000,000.00'), 10000000)
+    assert.equal(formatNumber('10,000.000.00'), 10000000)
+    assert.equal(formatNumber('10.000.000.00'), 10000000)
+  })
+
+  it('handles number input', () => {
+    assert.equal(formatNumber(10000000.0), 10000000)
+    assert.equal(formatNumber(9991234567), 9991234567)
+  })
+
+  it('does not handle non-numeric strings', () => {
+    assert.equal(formatNumber('ABCDEFGH'), undefined)
+    assert.equal(formatNumber('!@£$%^&*()'), undefined)
+    assert.equal(formatNumber('!A@B£C$D%E'), undefined)
+  })
+})

--- a/lib/nunjucks-filters/format-phone-number.js
+++ b/lib/nunjucks-filters/format-phone-number.js
@@ -1,0 +1,39 @@
+import parsePhoneNumber from 'libphonenumber-js'
+
+/**
+ * Format phone number
+ *
+ * @example '020 7450 4000'
+ * ```njk
+ * {{ '02074504000' | formatPhoneNumber }}
+ * ```
+ * @example '+44 20 7450 4000'
+ * ```njk
+ * {{ '02074504000' | formatPhoneNumber('GB') }}
+ * ```
+ * @example 'tel:+442074504000'
+ * ```njk
+ * {{ '02074504000' | formatPhoneNumber('GB', 'RFC3966') }}
+ * ```
+ * @param {string | number} [value] - Value to format
+ * @param {CountryCode} [countryCode] - Country code
+ * @param {NumberFormat} [format] - Number format
+ */
+export function formatPhoneNumber(value = '', countryCode, format) {
+  const phoneNumber = parsePhoneNumber(`${value}`, {
+    defaultCountry: countryCode ?? 'GB',
+    extract: false
+  })
+
+  if (!phoneNumber || !phoneNumber.isPossible()) {
+    return value
+  }
+
+  return countryCode
+    ? phoneNumber.format(format ?? 'INTERNATIONAL')
+    : phoneNumber.format(format ?? 'NATIONAL')
+}
+
+/**
+ * @import { CountryCode, NumberFormat } from 'libphonenumber-js'
+ */

--- a/lib/nunjucks-filters/format-phone-number.test.js
+++ b/lib/nunjucks-filters/format-phone-number.test.js
@@ -1,0 +1,84 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+
+import { formatPhoneNumber } from './format-phone-number.js'
+
+describe('formatPhoneNumber', () => {
+  it('should format phone numbers', () => {
+    assert.equal(formatPhoneNumber('111'), '111')
+    assert.equal(formatPhoneNumber('999'), '999')
+    assert.equal(formatPhoneNumber('01273800900'), '01273 800900')
+    assert.equal(formatPhoneNumber('02074504000'), '020 7450 4000')
+    assert.equal(formatPhoneNumber('07700900866'), '07700 900866')
+    assert.equal(formatPhoneNumber('0800890567'), '0800 890567')
+    assert.equal(formatPhoneNumber('08001111'), '0800 1111')
+  })
+
+  it('should format phone numbers (with country code)', () => {
+    assert.equal(formatPhoneNumber('01273800900', 'GB'), '+44 1273 800900')
+    assert.equal(formatPhoneNumber('02074504000', 'GB'), '+44 20 7450 4000')
+    assert.equal(formatPhoneNumber('07700900866', 'GB'), '+44 7700 900866')
+    assert.equal(formatPhoneNumber('0800890567', 'GB'), '+44 800 890567')
+    assert.equal(formatPhoneNumber('08001111', 'GB'), '+44 800 1111')
+
+    assert.equal(formatPhoneNumber('8005550100', 'US'), '+1 800 555 0100')
+    assert.equal(formatPhoneNumber('133457090', 'IT'), '+39 133457090')
+  })
+
+  it('should format phone numbers (with country code, national)', () => {
+    assert.equal(
+      formatPhoneNumber('01273800900', 'GB', 'NATIONAL'),
+      '01273 800900'
+    )
+
+    assert.equal(
+      formatPhoneNumber('02074504000', 'GB', 'NATIONAL'),
+      '020 7450 4000'
+    )
+
+    assert.equal(
+      formatPhoneNumber('0800890567', 'GB', 'NATIONAL'),
+      '0800 890567'
+    )
+
+    assert.equal(
+      formatPhoneNumber('07700900866', 'GB', 'NATIONAL'),
+      '07700 900866'
+    )
+
+    assert.equal(
+      formatPhoneNumber('8005550100', 'US', 'NATIONAL'),
+      '(800) 555-0100'
+    )
+
+    assert.equal(formatPhoneNumber('133457090', 'IT', 'NATIONAL'), '133457090')
+  })
+
+  it('should format phone numbers (for URLs)', () => {
+    assert.equal(
+      formatPhoneNumber('01273800900', 'GB', 'RFC3966'),
+      'tel:+441273800900'
+    )
+
+    assert.equal(
+      formatPhoneNumber('02074504000', 'GB', 'RFC3966'),
+      'tel:+442074504000'
+    )
+
+    assert.equal(
+      formatPhoneNumber('0800890567', 'GB', 'RFC3966'),
+      'tel:+44800890567'
+    )
+
+    assert.equal(
+      formatPhoneNumber('07700900866', 'GB', 'RFC3966'),
+      'tel:+447700900866'
+    )
+  })
+
+  it('should not format non-numeric strings', () => {
+    assert.equal(formatPhoneNumber('ABCDEFGH'), 'ABCDEFGH')
+    assert.equal(formatPhoneNumber('!@£$%^&*()'), '!@£$%^&*()')
+    assert.equal(formatPhoneNumber('!A@B£C$D%E'), '!A@B£C$D%E')
+  })
+})

--- a/lib/nunjucks-filters/index.js
+++ b/lib/nunjucks-filters/index.js
@@ -1,3 +1,4 @@
+import { formatCurrency } from './format-currency.js'
 import { formatDate } from './format-date.js'
 import { formatNhsNumber } from './format-nhs-number.js'
 import { formatNumber } from './format-number.js'
@@ -10,6 +11,7 @@ import { startsWith } from './starts-with.js'
  * @param {Environment} nunjucksEnv
  */
 export function addAll(nunjucksEnv) {
+  nunjucksEnv.addFilter('formatCurrency', formatCurrency)
   nunjucksEnv.addFilter('formatDate', formatDate)
   nunjucksEnv.addFilter('formatNhsNumber', formatNhsNumber)
   nunjucksEnv.addFilter('formatNumber', formatNumber)
@@ -22,6 +24,7 @@ export function addAll(nunjucksEnv) {
 }
 
 export {
+  formatCurrency,
   formatDate,
   formatNhsNumber,
   formatNumber,

--- a/lib/nunjucks-filters/index.js
+++ b/lib/nunjucks-filters/index.js
@@ -1,5 +1,6 @@
 import { formatDate } from './format-date.js'
 import { formatNhsNumber } from './format-nhs-number.js'
+import { formatNumber } from './format-number.js'
 import { formatPostcode } from './format-postcode.js'
 import { isNumeric } from './is-numeric.js'
 import { log } from './log.js'
@@ -11,6 +12,7 @@ import { startsWith } from './starts-with.js'
 export function addAll(nunjucksEnv) {
   nunjucksEnv.addFilter('formatDate', formatDate)
   nunjucksEnv.addFilter('formatNhsNumber', formatNhsNumber)
+  nunjucksEnv.addFilter('formatNumber', formatNumber)
   nunjucksEnv.addFilter('formatPostcode', formatPostcode)
   nunjucksEnv.addFilter('isNumeric', isNumeric)
   nunjucksEnv.addFilter('log', log)
@@ -22,6 +24,7 @@ export function addAll(nunjucksEnv) {
 export {
   formatDate,
   formatNhsNumber,
+  formatNumber,
   formatPostcode,
   isNumeric,
   log,

--- a/lib/nunjucks-filters/index.js
+++ b/lib/nunjucks-filters/index.js
@@ -1,6 +1,7 @@
 import { formatDate } from './format-date.js'
 import { formatNhsNumber } from './format-nhs-number.js'
 import { formatPostcode } from './format-postcode.js'
+import { isNumeric } from './is-numeric.js'
 import { log } from './log.js'
 import { startsWith } from './starts-with.js'
 
@@ -11,13 +12,21 @@ export function addAll(nunjucksEnv) {
   nunjucksEnv.addFilter('formatDate', formatDate)
   nunjucksEnv.addFilter('formatNhsNumber', formatNhsNumber)
   nunjucksEnv.addFilter('formatPostcode', formatPostcode)
+  nunjucksEnv.addFilter('isNumeric', isNumeric)
   nunjucksEnv.addFilter('log', log)
   nunjucksEnv.addFilter('startsWith', startsWith)
 
   return nunjucksEnv
 }
 
-export { formatDate, formatNhsNumber, formatPostcode, log, startsWith }
+export {
+  formatDate,
+  formatNhsNumber,
+  formatPostcode,
+  isNumeric,
+  log,
+  startsWith
+}
 
 /**
  * @import { Environment } from 'nunjucks'

--- a/lib/nunjucks-filters/is-numeric.js
+++ b/lib/nunjucks-filters/is-numeric.js
@@ -1,0 +1,17 @@
+/**
+ * Check value is numeric
+ *
+ * @param {unknown} [value] - Value to check
+ * @returns {value is string | number}
+ */
+export function isNumeric(value) {
+  if (typeof value !== 'string' && typeof value !== 'number') {
+    return false
+  }
+
+  if (typeof value === 'number') {
+    return Number.isFinite(value)
+  }
+
+  return !Number.isNaN(parseFloat(`${value}`)) && Number.isFinite(Number(value))
+}

--- a/lib/nunjucks-filters/is-numeric.test.js
+++ b/lib/nunjucks-filters/is-numeric.test.js
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+
+import { isNumeric } from './is-numeric.js'
+
+describe('numeric', () => {
+  it('matches numeric values', () => {
+    assert.equal(isNumeric('0'), true)
+    assert.equal(isNumeric('00'), true)
+    assert.equal(isNumeric('1'), true)
+    assert.equal(isNumeric('10'), true)
+    assert.equal(isNumeric('01'), true)
+    assert.equal(isNumeric('9991234567'), true)
+  })
+
+  it('matches number values', () => {
+    assert.equal(isNumeric(0), true)
+    assert.equal(isNumeric(-0), true)
+    assert.equal(isNumeric(1), true)
+    assert.equal(isNumeric(-1), true)
+    assert.equal(isNumeric(150), true)
+    assert.equal(isNumeric(-150), true)
+    assert.equal(isNumeric(10000), true)
+    assert.equal(isNumeric(10000000), true)
+  })
+
+  it('does not match non-numeric values', () => {
+    assert.equal(isNumeric(), false)
+    assert.equal(isNumeric(NaN), false)
+    assert.equal(isNumeric(Infinity), false)
+    assert.equal(isNumeric(null), false)
+    assert.equal(isNumeric(undefined), false)
+    assert.equal(isNumeric(false), false)
+    assert.equal(isNumeric(true), false)
+    assert.equal(isNumeric({}), false)
+    assert.equal(isNumeric([]), false)
+    assert.equal(isNumeric(''), false)
+    assert.equal(isNumeric('AA'), false)
+    assert.equal(isNumeric('1A'), false)
+    assert.equal(isNumeric('A1'), false)
+    assert.equal(isNumeric('1e'), false)
+  })
+})

--- a/lib/nunjucks-filters/starts-with.js
+++ b/lib/nunjucks-filters/starts-with.js
@@ -5,10 +5,13 @@
  * ```njk
  * {{ startsWith("NHS England", "NHS") }}
  * ```
- * @param {string} string - String to check
- * @param {string} value - Value to check against
- * @returns {boolean} Returns `true` if `string` starts with `value`, else `false`
+ * @param {string | number} [value] - Value to check
+ * @param {string | number} [searchValue] - Value to check against
  */
-export function startsWith(string, value) {
-  return string.startsWith(value)
+export function startsWith(value, searchValue) {
+  if (typeof value === 'undefined' || typeof searchValue === 'undefined') {
+    return false
+  }
+
+  return `${value}`.startsWith(`${searchValue}`)
 }

--- a/lib/nunjucks-filters/starts-with.test.js
+++ b/lib/nunjucks-filters/starts-with.test.js
@@ -11,4 +11,13 @@ describe('startsWith', () => {
   it('does not match string', () => {
     assert.equal(startsWith('DHSC', 'NHS'), false)
   })
+
+  it('does not match with missing value', () => {
+    assert.equal(startsWith('DHSC'), false)
+  })
+
+  it('handles number input', () => {
+    assert.equal(startsWith(9991234567, '9991234567'), true)
+    assert.equal(startsWith(9991234567, 9991234567), true)
+  })
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "express-flash": "^0.0.2",
         "express-session": "^1.19.0",
         "http-proxy-node16": "^1.0.6",
+        "libphonenumber-js": "^1.12.41",
         "nodemon": "^3.1.14",
         "portscanner": "^2.2.0",
         "sass-embedded": "^1.98.0",
@@ -6235,6 +6236,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/libphonenumber-js": {
+      "version": "1.12.41",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.12.41.tgz",
+      "integrity": "sha512-lsmMmGXBxXIK/VMLEj0kL6MtUs1kBGj1nTCzi6zgQoG1DEwqwt2DQyHxcLykceIxAnfE3hya7NuIh6PpC6S3fA==",
+      "license": "MIT"
     },
     "node_modules/limiter": {
       "version": "1.1.5",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "express-flash": "^0.0.2",
     "express-session": "^1.19.0",
     "http-proxy-node16": "^1.0.6",
+    "libphonenumber-js": "^1.12.41",
     "nodemon": "^3.1.14",
     "portscanner": "^2.2.0",
     "sass-embedded": "^1.98.0",


### PR DESCRIPTION
This PR brings some filters over from other prototypes I've worked on

Closes the following issues:

* https://github.com/nhsuk/nhsuk-prototype-kit-package/issues/57
* https://github.com/nhsuk/nhsuk-prototype-kit-package/issues/59
* https://github.com/nhsuk/nhsuk-prototype-kit-package/issues/215

With these filters added:

* c12707aaccf3adc9f0889ac6645b85fade6b4a9b Add filter `formatPhoneNumber`
* fe9b2dedd62fa34eb0d00e141a2f77bad14ca221 Add filter `formatCurrency`
* 59c37149ec7a754fa4b05040347fd11d75533b54 Add filter `formatNumber`
* 1db743cea71053d3c3e14efbfcc6f27cff392651 Add filter `isNumeric`