### PR TITLE
Updates for nhsuk frontend 10.4

### DIFF
--- a/lib/views/password.html
+++ b/lib/views/password.html
@@ -29,9 +29,9 @@
         </p>
 
         {{ passwordInput({
-          classes: "nhsuk-input--width-10",
           name: "password",
           id: "password",
+          width: 10,
           errorMessage: {
             text: "The password is not correct"
           } if errors | length and "wrong-password" in errors,

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
       },
       "peerDependencies": {
         "express": "^5.2.0",
-        "nhsuk-frontend": "^10.3.0 || >=11.0.0-preview || >=11.0.0-internal || >=11.0.0-beta",
+        "nhsuk-frontend": "^10.4.0 || >=11.0.0-preview || >=11.0.0-internal || >=11.0.0-beta",
         "nunjucks": "^3.2.4"
       }
     },

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   },
   "peerDependencies": {
     "express": "^5.2.0",
-    "nhsuk-frontend": "^10.3.0 || >=11.0.0-preview || >=11.0.0-internal || >=11.0.0-beta",
+    "nhsuk-frontend": "^10.4.0 || >=11.0.0-preview || >=11.0.0-internal || >=11.0.0-beta",
     "nunjucks": "^3.2.4"
   },
   "devDependencies": {


### PR DESCRIPTION
This bumps the minimum NHS.UK frontend version to 10.4.

This allows us to use the new `width` param on the password page.

As this is a backwards-compatible change, there should be no impact on users.