### PR TITLE
Add test for Nunjucks search paths including custom `viewsPath` option

### DIFF
--- a/lib/nhsuk-prototype-kit.test.js
+++ b/lib/nhsuk-prototype-kit.test.js
@@ -257,18 +257,6 @@ describe('NHSPrototypeKit', () => {
       assert.equal(prototype.nunjucks.opts.noCache, true)
     })
 
-    it('should initialize with custom `viewsPath` option', async () => {
-      const customViewsPath = '/custom/views'
-      const prototype = await NHSPrototypeKit.init({
-        viewsPath: customViewsPath
-      })
-
-      assert.ok(
-        // @ts-expect-error - Property 'loaders' does not exist
-        prototype.nunjucks.loaders[0].searchPaths.includes(customViewsPath)
-      )
-    })
-
     it('should initialize with all options', async () => {
       const routes = express.Router()
 

--- a/lib/nhsuk-prototype-kit.test.js
+++ b/lib/nhsuk-prototype-kit.test.js
@@ -202,7 +202,7 @@ describe('NHSPrototypeKit', () => {
       assert.deepEqual(prototype.app.get('views'), searchPaths)
     })
 
-    it('should configure nunjucks with correct paths', async () => {
+    it('should configure nunjucks search paths', async () => {
       const prototype = await NHSPrototypeKit.init()
 
       // @ts-expect-error - Property 'loaders' does not exist
@@ -224,6 +224,32 @@ describe('NHSPrototypeKit', () => {
       ])
     })
 
+    it('should configure nunjucks search paths with custom `viewsPath` option', async () => {
+      const customViewsPath = 'app/views'
+      const prototype = await NHSPrototypeKit.init({
+        viewsPath: customViewsPath
+      })
+
+      // @ts-expect-error - Property 'loaders' does not exist
+      const { searchPaths } = prototype.nunjucks.loaders[0]
+
+      // Should have nunjucks configured
+      assert.ok(prototype.nunjucks)
+      assert.ok(searchPaths)
+
+      assert.deepEqual(searchPaths, [
+        customViewsPath,
+        config.appPath,
+        join(config.prototypeKitPath, 'lib/views'),
+        join(config.nhsukFrontendPath, 'dist/nhsuk/components'),
+        join(config.nhsukFrontendPath, 'dist/nhsuk/macros'),
+        join(config.nhsukFrontendPath, 'dist/nhsuk'),
+        join(config.nhsukFrontendPath, 'dist'),
+        join(config.prototypeKitPath, 'node_modules'),
+        config.moduleBase
+      ])
+    })
+
     it('should set noCache to true on nunjucks environment', async () => {
       const prototype = await NHSPrototypeKit.init()
 
@@ -231,7 +257,7 @@ describe('NHSPrototypeKit', () => {
       assert.equal(prototype.nunjucks.opts.noCache, true)
     })
 
-    it('should initialize with custom viewsPath', async () => {
+    it('should initialize with custom `viewsPath` option', async () => {
       const customViewsPath = '/custom/views'
       const prototype = await NHSPrototypeKit.init({
         viewsPath: customViewsPath


### PR DESCRIPTION
This PR adds a test to configure nunjucks search paths with custom `viewsPath` option