### PR TITLE
Use code component on error page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,10 @@
 
 - Make sure internal views use admin layout
 - Fix custom routes to Nunjucks views
+- Add import for NHS.UK frontend code component
 - Add import for NHS.UK frontend legend component
 - Import NHS.UK frontend components using namespace directory
+- Improve error page styling
 
 ## 8.2.1 - 5 May 2026
 

--- a/lib/views/500.html
+++ b/lib/views/500.html
@@ -2,25 +2,33 @@
 
 {% set pageName = "Sorry, there is a problem with the prototype" %}
 
-{% set stackHtml -%}
-<pre class="nhsuk-u-margin-0" tabindex="0"><code class="nhsuk-u-font-size-14">{{ error.stack }}</code></pre>
-{%- endset %}
-
 {% block content %}
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
 
       <h1 class="nhsuk-heading-l">{{ pageName }}</h1>
-
       <h2 class="nhsuk-heading-m">{{ error.name }}</h2>
 
-      <p class="nhsuk-caption-m">{{ error.message | nl2br | nl2br | safe }}</p>
-      {{ details({
-        summaryText: "Stack trace",
-        html: stackHtml
+    </div>
+  </div>
+  <div class="nhsuk-grid-row">
+    <div class="nhsuk-grid-column-full">
+
+      {{ code({
+        html: error.message | nl2br | nl2br,
+        classes: "nhsuk-u-reading-width"
       }) }}
 
-      <pre class="nhsuk-u-margin-top-8">Status code: {{ error.status }}</pre>
+      {{ details({
+        summaryText: "Stack trace",
+        html: code({
+          html: error.stack,
+          variant: "reverse"
+        })
+      }) }}
+
+      <p><samp>Status code: {{ error.status }}</samp></p>
+
     </div>
   </div>
 {% endblock %}

--- a/lib/views/prototype-kit-template.njk
+++ b/lib/views/prototype-kit-template.njk
@@ -7,6 +7,7 @@
 {%- from "nhsuk/components/card/macro.njk" import card %}
 {%- from "nhsuk/components/character-count/macro.njk" import characterCount %}
 {%- from "nhsuk/components/checkboxes/macro.njk" import checkboxes %}
+{%- from "nhsuk/components/code/macro.njk" import code %}
 {%- from "nhsuk/components/contents-list/macro.njk" import contentsList %}
 {%- from "nhsuk/components/date-input/macro.njk" import dateInput %}
 {%- from "nhsuk/components/details/macro.njk" import details %}


### PR DESCRIPTION
This PR replaces `<pre>` code blocks with the NHS.UK frontend code component

<br>

<img width="2276" height="2170" alt="Error page with code component" src="https://github.com/user-attachments/assets/c4bad01d-db0c-4d76-8f95-589922b1baa8" />
