### PR TITLE
Fix 404 handling for unknown file types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # NHS prototype kit Changelog
 
+## Unreleased
+
+### :wrench: **Fixes**
+
+- Fix 404 handling for unknown file types
+
 ## 8.2.2 - 7 May 2026
 
 ### :wrench: **Fixes**

--- a/lib/express/nunjucks-auto-routing-view.js
+++ b/lib/express/nunjucks-auto-routing-view.js
@@ -36,7 +36,9 @@ export class NunjucksAutoRoutingView {
    * @param {NunjucksViewCallback} callback
    */
   render(options, callback) {
-    const nunjucksRender = this.engines?.[this.ext]
+    const nunjucksRender =
+      this.engines?.[this.ext] ?? // Try Express.js available engines
+      this.engines?.[`.${this.defaultEngine}`] // Fallback to default
 
     if (!nunjucksRender) {
       return callback(new Error(`Failed to lookup view engine "${this.ext}"`))

--- a/lib/middleware/auto-routes.test.js
+++ b/lib/middleware/auto-routes.test.js
@@ -101,8 +101,20 @@ describe('autoRoutes', () => {
       assert.equal(response.text, 'Not found')
     })
 
+    it('should call next() for non-existent file', async () => {
+      const response = await request(server).get('/favicon.ico')
+      assert.equal(response.status, 404)
+      assert.equal(response.text, 'Not found')
+    })
+
     it('should call next() for non-existent nested path', async () => {
       const response = await request(server).get('/path/does/not/exist')
+      assert.equal(response.status, 404)
+      assert.equal(response.text, 'Not found')
+    })
+
+    it('should call next() for non-existent nested file', async () => {
+      const response = await request(server).get('/path/does/not/manifest.json')
       assert.equal(response.status, 404)
       assert.equal(response.text, 'Not found')
     })


### PR DESCRIPTION
This PR fixes a bug in the last release

Since [v8.2.2](https://github.com/nhsuk/nhsuk-prototype-kit-package/releases/tag/v8.2.2) we only render `*.html` and `*.njk` file types

But previously the [Nunjucks view engine for Express](https://github.com/mozilla/nunjucks/blob/master/nunjucks/src/express-app.js#L17-L19) rendered all files types

Requests for unknown files like `favicon.ico` throw quite beautiful error pages, but it should be fixed

```console
Failed to lookup view engine ".ico"
```

<img width="1052" height="906" alt="Error 500 requesting ico file" src="https://github.com/user-attachments/assets/0f47da94-3047-4549-9968-ef7659dbc6d2" />
