### PR TITLE
Fix error message rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # NHS prototype kit Changelog
 
+## Unreleased
+
+### :wrench: **Fixes**
+
+- Fix link to guidance on password not set error page
+- Add contact support message to error page
+
 ## 8.2.3 - 8 May 2026
 
 ### :wrench: **Fixes**

--- a/lib/middleware/authentication.js
+++ b/lib/middleware/authentication.js
@@ -56,6 +56,8 @@ function showNoPasswordError(req, res, next) {
   )
 
   error.name = 'Password not set'
+  delete error.stack
+
   res.status(401) // Unauthorized
 
   return next(error)

--- a/lib/middleware/render-error-page.js
+++ b/lib/middleware/render-error-page.js
@@ -7,7 +7,9 @@
 export function renderErrorPage(error, req, res, _next) {
   error.status ??= 500
 
-  console.error(error.stack)
+  if (error.stack) {
+    console.error(error.stack)
+  }
 
   if (res.statusCode !== 200) {
     error.status = res.statusCode

--- a/lib/views/500.html
+++ b/lib/views/500.html
@@ -7,7 +7,11 @@
     <div class="nhsuk-grid-column-two-thirds">
 
       <h1 class="nhsuk-heading-l">{{ pageName }}</h1>
-      <h2 class="nhsuk-heading-m nhsuk-u-margin-bottom-2">{{ error.name }}</h2>
+      <h2 class="nhsuk-heading-m">{{ error.name }}</h2>
+
+      <p class="nhsuk-body">
+        You can try and fix this yourself or <a class="nhsuk-link" href="https://prototype-kit.service-manual.nhs.uk/support/">contact the NHS prototype kit team</a> if you need help.
+      </p>
 
       <p class="nhsuk-caption-m nhsuk-u-reading-width">
         {{- error.message | nl2br | nl2br | safe -}}

--- a/lib/views/500.html
+++ b/lib/views/500.html
@@ -19,6 +19,7 @@
 
     </div>
   </div>
+{% if error.stack %}
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-full">
 
@@ -34,5 +35,6 @@
 
     </div>
   </div>
+{% endif %}
 {% endblock %}
 

--- a/lib/views/500.html
+++ b/lib/views/500.html
@@ -7,17 +7,16 @@
     <div class="nhsuk-grid-column-two-thirds">
 
       <h1 class="nhsuk-heading-l">{{ pageName }}</h1>
-      <h2 class="nhsuk-heading-m">{{ error.name }}</h2>
+      <h2 class="nhsuk-heading-m nhsuk-u-margin-bottom-2">{{ error.name }}</h2>
+
+      <p class="nhsuk-caption-m nhsuk-u-reading-width">
+        {{- error.message | nl2br | nl2br | safe -}}
+      </p>
 
     </div>
   </div>
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-full">
-
-      {{ code({
-        html: error.message | nl2br | nl2br,
-        classes: "nhsuk-u-reading-width"
-      }) }}
 
       {{ details({
         summaryText: "Stack trace",

--- a/lib/views/500.html
+++ b/lib/views/500.html
@@ -7,13 +7,14 @@
     <div class="nhsuk-grid-column-two-thirds">
 
       <h1 class="nhsuk-heading-l">{{ pageName }}</h1>
-      <h2 class="nhsuk-heading-m">{{ error.name }}</h2>
 
       <p class="nhsuk-body">
         You can try and fix this yourself or <a class="nhsuk-link" href="https://prototype-kit.service-manual.nhs.uk/support/">contact the NHS prototype kit team</a> if you need help.
       </p>
 
-      <p class="nhsuk-caption-m nhsuk-u-reading-width">
+      <h2 class="nhsuk-heading-m">{{ error.name }}</h2>
+
+      <p>
         {{- error.message | nl2br | nl2br | safe -}}
       </p>
 


### PR DESCRIPTION
This PR moves the error message from `<pre>` back into regular HTML.

I've also added the contact support message (copied from the 404 page).

See changes in https://github.com/nhsuk/nhsuk-prototype-kit-package/pull/326

## Before

The error message HTML is rendered (escaped) in a code component:

<img width="768" alt="Error message in code block" src="https://github.com/user-attachments/assets/73f25e5a-6658-4953-934b-ad9883a2b397" />

## After

The error message HTML is rendered as HTML again:

<img width="1048" height="572" alt="Screenshot 2026-06-03 at 10 23 43" src="https://github.com/user-attachments/assets/2697e76c-cc71-4f56-9d3c-30bc64fcc8f0" />

<img width="1013" height="1062" alt="Screenshot 2026-06-03 at 10 22 36" src="https://github.com/user-attachments/assets/803ed2de-5c98-407a-a2d4-cf7635978101" />
