### PR TITLE
Use NHS frontend 10.5.1 and new template with imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # NHS prototype kit Changelog
 
+## Unreleased
+
+### :wrench: **Maintenance**
+
+- Update to use NHS frontend 10.5 and the new `template-with-imports.njk` template.
+
 ## 8.2.3 - 8 May 2026
 
 ### :wrench: **Fixes**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### :wrench: **Maintenance and fixes**
 
-- Update to use NHS frontend 10.5 and the new `template-with-imports.njk` template.
+- Update to use NHS.UK frontend 10.5 and the new `template-with-imports.njk` template.
 - Fix link to guidance on password not set error page
 - Add contact support message to error page
 

--- a/lib/views/prototype-kit-template.njk
+++ b/lib/views/prototype-kit-template.njk
@@ -1,44 +1,4 @@
-{% extends "template.njk" %}
-
-{%- from "nhsuk/components/action-link/macro.njk" import actionLink %}
-{%- from "nhsuk/components/back-link/macro.njk" import backLink %}
-{%- from "nhsuk/components/breadcrumb/macro.njk" import breadcrumb %}
-{%- from "nhsuk/components/button/macro.njk" import button %}
-{%- from "nhsuk/components/card/macro.njk" import card %}
-{%- from "nhsuk/components/character-count/macro.njk" import characterCount %}
-{%- from "nhsuk/components/checkboxes/macro.njk" import checkboxes %}
-{%- from "nhsuk/components/code/macro.njk" import code %}
-{%- from "nhsuk/components/contents-list/macro.njk" import contentsList %}
-{%- from "nhsuk/components/date-input/macro.njk" import dateInput %}
-{%- from "nhsuk/components/details/macro.njk" import details %}
-{%- from "nhsuk/components/do-dont-list/macro.njk" import list %}
-{%- from "nhsuk/components/error-message/macro.njk" import errorMessage %}
-{%- from "nhsuk/components/error-summary/macro.njk" import errorSummary %}
-{%- from "nhsuk/components/fieldset/macro.njk" import fieldset %}
-{%- from "nhsuk/components/file-upload/macro.njk" import fileUpload %}
-{%- from "nhsuk/components/footer/macro.njk" import footer %}
-{%- from "nhsuk/components/header/macro.njk" import header %}
-{%- from "nhsuk/components/hero/macro.njk" import hero %}
-{%- from "nhsuk/components/hint/macro.njk" import hint %}
-{%- from "nhsuk/components/images/macro.njk" import image %}
-{%- from "nhsuk/components/input/macro.njk" import input %}
-{%- from "nhsuk/components/inset-text/macro.njk" import insetText %}
-{%- from "nhsuk/components/label/macro.njk" import label %}
-{%- from "nhsuk/components/legend/macro.njk" import legend %}
-{%- from "nhsuk/components/notification-banner/macro.njk" import notificationBanner %}
-{%- from "nhsuk/components/pagination/macro.njk" import pagination %}
-{%- from "nhsuk/components/panel/macro.njk" import panel %}
-{%- from "nhsuk/components/password-input/macro.njk" import passwordInput %}
-{%- from "nhsuk/components/radios/macro.njk" import radios %}
-{%- from "nhsuk/components/select/macro.njk" import select %}
-{%- from "nhsuk/components/skip-link/macro.njk" import skipLink %}
-{%- from "nhsuk/components/summary-list/macro.njk" import summaryList %}
-{%- from "nhsuk/components/tables/macro.njk" import table %}
-{%- from "nhsuk/components/tabs/macro.njk" import tabs %}
-{%- from "nhsuk/components/tag/macro.njk" import tag %}
-{%- from "nhsuk/components/task-list/macro.njk" import taskList %}
-{%- from "nhsuk/components/textarea/macro.njk" import textarea %}
-{%- from "nhsuk/components/warning-callout/macro.njk" import warningCallout %}
+{% extends "template-with-imports.njk" %}
 
 {% block pageTitle -%}
   {%- if errors === true or (errors | length) %}Error: {% endif -%}

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
       },
       "peerDependencies": {
         "express": "^5.2.0",
-        "nhsuk-frontend": "^10.5.0 || >=11.0.0-preview || >=11.0.0-internal || >=11.0.0-beta",
+        "nhsuk-frontend": "^10.5.1 || >=11.0.0-preview || >=11.0.0-internal || >=11.0.0-beta",
         "nunjucks": "^3.2.4"
       }
     },
@@ -7412,9 +7412,9 @@
       }
     },
     "node_modules/nhsuk-frontend": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/nhsuk-frontend/-/nhsuk-frontend-10.5.0.tgz",
-      "integrity": "sha512-VCvUXrC8edYekhpuEyaZ8qnIRnxfJT3pO5P0YZm07kXXOXbatTtXbfJ6g99NxqhbiANpUvwEVc8YJOnXgZw7/Q==",
+      "version": "10.5.1",
+      "resolved": "https://registry.npmjs.org/nhsuk-frontend/-/nhsuk-frontend-10.5.1.tgz",
+      "integrity": "sha512-O6GqxHZ6UBePTc7uiItNttZoi8+J3dTC5vUN6bMs0cAoL8TgvNOiYwppFMrMB/nHVk+PtFtf+F8x2tz7OdNS1Q==",
       "license": "MIT",
       "engines": {
         "node": "^20.9.0 || ^22.11.0 || >= 24.11.0"
@@ -10434,7 +10434,7 @@
       "license": "MIT",
       "dependencies": {
         "express": "^5.2.1",
-        "nhsuk-frontend": "^10.5.0",
+        "nhsuk-frontend": "^10.5.1",
         "nhsuk-prototype-kit": "*",
         "nunjucks": "^3.2.4"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
       },
       "peerDependencies": {
         "express": "^5.2.0",
-        "nhsuk-frontend": "^10.4.0 || >=11.0.0-preview || >=11.0.0-internal || >=11.0.0-beta",
+        "nhsuk-frontend": "^10.5.0 || >=11.0.0-preview || >=11.0.0-internal || >=11.0.0-beta",
         "nunjucks": "^3.2.4"
       }
     },
@@ -7412,9 +7412,9 @@
       }
     },
     "node_modules/nhsuk-frontend": {
-      "version": "10.4.2",
-      "resolved": "https://registry.npmjs.org/nhsuk-frontend/-/nhsuk-frontend-10.4.2.tgz",
-      "integrity": "sha512-DYa7E/jwWtQPKqzeF9eB9nVcTKHpjMYf+SydKao379qQapIkblfS2BNvKsVKuWpI0w+QgI8XSDNNOUTQEGRb1w==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/nhsuk-frontend/-/nhsuk-frontend-10.5.0.tgz",
+      "integrity": "sha512-VCvUXrC8edYekhpuEyaZ8qnIRnxfJT3pO5P0YZm07kXXOXbatTtXbfJ6g99NxqhbiANpUvwEVc8YJOnXgZw7/Q==",
       "license": "MIT",
       "engines": {
         "node": "^20.9.0 || ^22.11.0 || >= 24.11.0"
@@ -10434,7 +10434,7 @@
       "license": "MIT",
       "dependencies": {
         "express": "^5.2.1",
-        "nhsuk-frontend": "^10.4.2",
+        "nhsuk-frontend": "^10.5.0",
         "nhsuk-prototype-kit": "*",
         "nunjucks": "^3.2.4"
       },

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   },
   "peerDependencies": {
     "express": "^5.2.0",
-    "nhsuk-frontend": "^10.5.0 || >=11.0.0-preview || >=11.0.0-internal || >=11.0.0-beta",
+    "nhsuk-frontend": "^10.5.1 || >=11.0.0-preview || >=11.0.0-internal || >=11.0.0-beta",
     "nunjucks": "^3.2.4"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   },
   "peerDependencies": {
     "express": "^5.2.0",
-    "nhsuk-frontend": "^10.4.0 || >=11.0.0-preview || >=11.0.0-internal || >=11.0.0-beta",
+    "nhsuk-frontend": "^10.5.0 || >=11.0.0-preview || >=11.0.0-internal || >=11.0.0-beta",
     "nunjucks": "^3.2.4"
   },
   "devDependencies": {

--- a/testapp/package.json
+++ b/testapp/package.json
@@ -9,7 +9,7 @@
   "license": "MIT",
   "dependencies": {
     "express": "^5.2.1",
-    "nhsuk-frontend": "^10.5.0",
+    "nhsuk-frontend": "^10.5.1",
     "nhsuk-prototype-kit": "*",
     "nunjucks": "^3.2.4"
   },

--- a/testapp/package.json
+++ b/testapp/package.json
@@ -9,7 +9,7 @@
   "license": "MIT",
   "dependencies": {
     "express": "^5.2.1",
-    "nhsuk-frontend": "^10.4.2",
+    "nhsuk-frontend": "^10.5.0",
     "nhsuk-prototype-kit": "*",
     "nunjucks": "^3.2.4"
   },


### PR DESCRIPTION
Switching to the new `template-with-imports.njk` template from NHS frontend 10.5.1 means we don’t have to import all the components ourselves.

This also imports the new **Search input** component, and will import any future new components without needing a release of the NHS prototype kit.